### PR TITLE
Hovermenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ yarn add prosemirror-suggestion-mode
 ### Basic Setup
 
 ```javascript
-import { suggestionsPlugin } from 'prosemirror-suggestion-mode'
+import { suggestionModePlugin } from 'prosemirror-suggestion-mode'
 
 // Add to your ProseMirror plugins
 const plugins = [
-  suggestionsPlugin,
+  suggestionModePlugin,
   // ... other plugins
 ]
 ```
@@ -52,7 +52,7 @@ const plugins = [
 
 ```javascript
 // Enable suggestion mode with username and custom data
-view.dispatch(view.state.tr.setMeta(suggestionsPlugin, {
+view.dispatch(view.state.tr.setMeta(suggestionModePlugin, {
   suggestionMode: true,
   username: 'JohnDoe',
   data: {
@@ -63,12 +63,12 @@ view.dispatch(view.state.tr.setMeta(suggestionsPlugin, {
 }))
 
 // Disable suggestion mode
-view.dispatch(view.state.tr.setMeta(suggestionsPlugin, {
+view.dispatch(view.state.tr.setMeta(suggestionModePlugin, {
   suggestionMode: false
 }))
 
 // Change username and data
-view.dispatch(view.state.tr.setMeta(suggestionsPlugin, {
+view.dispatch(view.state.tr.setMeta(suggestionModePlugin, {
   suggestionMode: true,
   username: 'JaneSmith',
   data: {
@@ -89,10 +89,10 @@ Each suggestion will now be tagged with the username of the person who made it. 
 
 ```javascript
 // Accept a suggestion at the current selection
-suggestionsPlugin.accept(view)
+suggestionModePlugin.accept(view)
 
 // Reject a suggestion at the current selection
-suggestionsPlugin.reject(view)
+suggestionModePlugin.reject(view)
 ```
 
 ### Customizing Tooltips
@@ -105,7 +105,7 @@ Provide a custom tooltip renderer function when creating the plugin.  If you add
 
 ```javascript
 new Plugin({
-    ...suggestionsPlugin,
+    ...suggestionModePlugin,
     tooltipRenderer: (mark, type) => {
         // mark contains attrs like username, createdAt
         // type is either 'add' or 'delete'

--- a/README.md
+++ b/README.md
@@ -173,12 +173,6 @@ The development server will be available at:
 http://localhost:8080
 
 
-## TODO
-
-- make hover menu customizable
-- combine accepting and rejecting two an add and delete together when next to each other (potentially make a suggestion_replace mark)
-- add reasons to suggestions display
-
 ## Implementation choices
 
 For simplicity this is not really a diffing capability where you can input two different versions and see the changes.  Instead if a user makes changes with a suggestion mode enabled, the changes are stored as extra markup on the document.  It's not really version control, it's just a way to make suggestions.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ http://localhost:8080
 
 ## TODO
 
+- make hover menu customizable
 - combine accepting and rejecting two an add and delete together when next to each other (potentially make a suggestion_replace mark)
 - add reasons to suggestions display
 

--- a/examples/inkAndSwitch/index.html
+++ b/examples/inkAndSwitch/index.html
@@ -3,12 +3,21 @@
 <head>
     <meta charset="utf-8">
     <title>ProseMirror Suggestions Ink & Switch hidden diffs example</title>
+    <!-- Add Prism.js CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism.min.css" rel="stylesheet" />
     <style>
         body {
             line-height: 1.5;
             margin: 0;
             padding: 20px;
-            text-align: center;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            width: 800px;
+            text-align: left;
+            margin-left: auto;
+            margin-right: auto;
         }
         .ProseMirror {
             white-space: pre-wrap;
@@ -31,10 +40,11 @@
     </style>
 </head>
 <body>
-    <h1>Prosemirror Suggestion Mode Ink & Switch hidden diffs example</h1>
+    <div class="container">
+        <h1>Prosemirror Suggestion Mode Ink & Switch hidden diffs example</h1>
 
-    <p style="color: red;">This is a WIP, currently removing deletes malfunctions</p>
-    <p>Ink & Switch propose a way of <a href="https://www.inkandswitch.com/patchwork/notebook/04/">visualising suggestion diffs</a> by hiding the deletes behind a hover. This example shows how to add additional decorations should you need them.</p>
+
+
     <div class="controls">
         <label>
             <input type="checkbox" id="toggleSuggestionMode" checked> Suggest/edit mode
@@ -47,5 +57,107 @@
     </div>
     <div id="editor" class="editor"></div>
     <script src="inkAndSwitch.js"></script>
+
+    <p>The hover menu that shows up when hovering on suggestions is customizable.  To  demonstrate this we'll implement <a href="https://www.inkandswitch.com/patchwork/notebook/04/">Ink & Switch's proposed UI for visualising suggestion diffs</a> which is to hide the deletes behind a hover.</p>
+
+    <p>To do this we'll use CSS to hide the removed text and instead show a simple placeholder icon for users to hover over to see that deleted text.</p>
+
+    <pre><code class="language-css">
+.suggestion-delete .suggestion-delete-wrapper {
+    display: none
+}
+
+.suggestion-delete::after {
+    content: "-";
+    display: inline-block;
+    width: 1ch;
+    background-color: rgba(255, 0, 0, 0.2);
+    color: red;
+}
+</code></pre>
+
+    <p>Next we'll add the deleted text to the hoverMenu by providing a custom createInfoComponent - which displays the text in the hover menu.  Our custom component is</p>
+
+<pre><code class="language-javascript">
+const createDeletedTextInfoComponent = (mark, view, pos) => {
+  // Only show for delete suggestions
+  if (mark.type.name !== "suggestion_delete") {
+    return { dom: document.createElement("div") };
+  }
+
+  const deletedTextDiv = document.createElement("div");
+  deletedTextDiv.className = "suggestion-deleted-text";
+  
+  // Helper function that will find the full range of the mark
+  const markRange = findMarkRange(view.state, pos, "suggestion_delete");
+  
+  if (markRange) {
+    // Extract all text in the range
+    const deletedText = view.state.doc.textBetween(
+      markRange.from, 
+      markRange.to,
+      " "
+    );
+    
+    // Create the html along with the deleted text
+    const textSpan = document.createElement("span");
+    textSpan.textContent = deletedText;
+    textSpan.className = "deleted-text-content";
+    
+    const label = document.createElement("strong");
+    label.textContent = "Deleted text: ";
+    
+    deletedTextDiv.appendChild(label);
+    deletedTextDiv.appendChild(textSpan);
+  }
+  
+  return { dom: deletedTextDiv };
+};
+</code></pre>
+
+    <p>And we'll pass this component to the hoverMenu options when we initialise the plugin</p>
+
+<pre><code class="language-javascript">
+suggestionModePlugin({
+    hoverMenuOptions: {
+        components: {
+            createInfoComponent: createDeletedTextInfoComponent,
+        }
+    }
+})
+</code></pre>
+
+<p>Try deleting some text in the example above and you can see the newly custom styled hover menu.</p>
+
+    <p>The hover menu is made up of two parts, each of which you can override:    </p>
+
+         <pre><code class="language-javascript">
+hoverMenuOptions: {
+    components: {
+        createInfoComponent: // the information at the top of the hover menu
+        createButtonsComponent: // the buttons at the bottom of the hover menu
+    }
+}
+</code></pre>
+<p>You can also replace the whole hover menu by providing a custom hoverMenuRenderer</p>
+
+<pre><code class="language-javascript">
+const myCustomHoverMenuRenderer = (mark, view, pos) => {
+    return // the whole hover menu
+}
+
+suggestionModePlugin({
+    hoverMenuOptions: {
+        hoverMenuRenderer: myCustomHoverMenuRenderer
+    }
+})
+</code></pre>
+
+    </div>
+    
+    <!-- Add Prism.js JavaScript -->
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-javascript.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-css.min.js"></script>
 </body>
 </html>

--- a/examples/inkAndSwitch/inkAndSwitch.ts
+++ b/examples/inkAndSwitch/inkAndSwitch.ts
@@ -5,7 +5,6 @@ import { keymap } from "prosemirror-keymap";
 import { addListNodes } from "prosemirror-schema-list";
 import { Schema } from "prosemirror-model";
 import { schema } from "prosemirror-schema-basic";
-
 import {
   suggestionModePlugin,
   acceptAllSuggestions,

--- a/examples/inkAndSwitch/inkAndSwitch.ts
+++ b/examples/inkAndSwitch/inkAndSwitch.ts
@@ -11,10 +11,9 @@ import {
   rejectAllSuggestions,
   setSuggestionMode,
   addSuggestionMarks,
+  findMarkRange,
 } from "prosemirror-suggestion-mode";
 import { DOMParser } from "prosemirror-model";
-import { Decoration, DecorationSet } from "prosemirror-view";
-import { Plugin } from "prosemirror-state";
 
 // Normally you can just direct import a theme
 import "prosemirror-suggestion-mode/styles/inkAndSwitch.css";
@@ -27,42 +26,41 @@ const exampleSchema = new Schema({
   marks: addSuggestionMarks(schema.spec.marks),
 });
 
-// Extending the suggestion plugin with an extra decorator showing deleted text on hover
-const deletedTextDecorator = new Plugin({
-  state: {
-    init() {
-      return DecorationSet.empty;
-    },
-    apply(tr, oldSet) {
-      // Map decorations through document changes
-      const newSet = oldSet.map(tr.mapping, tr.doc);
+// Create a custom component for displaying deleted text in the hover menu
+const createDeletedTextInfoComponent = (mark, view, pos) => {
+  // Only show for delete suggestions
+  if (mark.type.name !== "suggestion_delete") {
+    return { dom: document.createElement("div") };
+  }
 
-      if (!tr.docChanged) return newSet;
-
-      // Find all suggestion-delete marks and create decorations
-      const decorations = [];
-      tr.doc.descendants((node, pos) => {
-        // Check each node's marks for suggestion-delete
-        node.marks.forEach((mark) => {
-          if (mark.type.name === "suggestion_delete") {
-            // Create a decoration for the full node that shows deleted text in tooltip
-            const decoration = Decoration.inline(pos, pos + node.nodeSize, {
-              class: "deleted-text-content",
-            });
-            decorations.push(decoration);
-          }
-        });
-      });
-
-      return newSet.add(tr.doc, decorations);
-    },
-  },
-  props: {
-    decorations(state) {
-      return this.getState(state);
-    },
-  },
-});
+  const deletedTextDiv = document.createElement("div");
+  deletedTextDiv.className = "suggestion-deleted-text";
+  
+  // Helper function that will find the full range of the mark
+  const markRange = findMarkRange(view.state, pos, "suggestion_delete");
+  
+  if (markRange) {
+    // Extract all text in the range
+    const deletedText = view.state.doc.textBetween(
+      markRange.from, 
+      markRange.to,
+      " "
+    );
+    
+    // Create the html along with the deleted text
+    const textSpan = document.createElement("span");
+    textSpan.textContent = deletedText;
+    textSpan.className = "deleted-text-content";
+    
+    const label = document.createElement("strong");
+    label.textContent = "Deleted text: ";
+    
+    deletedTextDiv.appendChild(label);
+    deletedTextDiv.appendChild(textSpan);
+  }
+  
+  return { dom: deletedTextDiv };
+};
 
 // Initialize the editor with the suggestions plugin
 window.addEventListener("load", () => {
@@ -79,9 +77,19 @@ window.addEventListener("load", () => {
   const state = EditorState.create({
     schema: exampleSchema,
     doc,
-    plugins: [keymap(baseKeymap), suggestionModePlugin({
-      username: "example user",
-    }), deletedTextDecorator],
+    plugins: [
+      keymap(baseKeymap), 
+      suggestionModePlugin({
+        username: "example user",
+        // Add hover menu options to show deleted text
+        hoverMenuOptions: {
+            components: {
+                createInfoComponent: createDeletedTextInfoComponent,
+            }
+       
+        }
+      })
+    ],
   });
 
   // Create the editor view
@@ -105,42 +113,4 @@ window.addEventListener("load", () => {
     ?.addEventListener("click", () => {
       rejectAllSuggestions(view);
     });
-});
-
-// Add a function to create tooltips for deleted text
-document.addEventListener("mouseover", (e) => {
-  const target = e.target as HTMLElement;
-  if (
-    target.classList.contains("suggestion-delete-with-tooltip") ||
-    target.closest(".suggestion-delete-with-tooltip")
-  ) {
-    const element = target.classList.contains("suggestion-delete-with-tooltip")
-      ? target
-      : target.closest(".suggestion-delete-with-tooltip");
-
-    if (!element) return;
-
-    // Get the deleted text from the data attribute
-    const deletedText = element.getAttribute("data-deleted-text");
-    if (!deletedText) return;
-
-    // Create or update tooltip
-    let tooltip = element.querySelector(".suggestion-deleted-content");
-    if (!tooltip) {
-      tooltip = document.createElement("div");
-      tooltip.className = "suggestion-tooltip suggestion-deleted-content";
-
-      const info = document.createElement("div");
-      info.className = "suggestion-info";
-      info.textContent = "Deleted text:";
-
-      const content = document.createElement("div");
-      content.className = "deleted-text-content";
-      content.textContent = deletedText;
-
-      tooltip.appendChild(info);
-      tooltip.appendChild(content);
-      element.appendChild(tooltip);
-    }
-  }
 });

--- a/examples/inkAndSwitch/inkAndSwitch.ts
+++ b/examples/inkAndSwitch/inkAndSwitch.ts
@@ -7,18 +7,18 @@ import { Schema } from "prosemirror-model";
 import { schema } from "prosemirror-schema-basic";
 
 import {
-  suggestionsPlugin,
+  suggestionModePlugin,
   acceptAllSuggestions,
   rejectAllSuggestions,
   setSuggestionMode,
   addSuggestionMarks,
-} from "prosemirror-suggest-mode";
+} from "prosemirror-suggestion-mode";
 import { DOMParser } from "prosemirror-model";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import { Plugin } from "prosemirror-state";
 
 // Normally you can just direct import a theme
-import "prosemirror-suggest-mode/styles/inkAndSwitch.css";
+import "prosemirror-suggestion-mode/styles/inkAndSwitch.css";
 
 const exampleSchema = new Schema({
   nodes: addListNodes(schema.spec.nodes, "paragraph block*", "block"),
@@ -80,7 +80,9 @@ window.addEventListener("load", () => {
   const state = EditorState.create({
     schema: exampleSchema,
     doc,
-    plugins: [keymap(baseKeymap), suggestionsPlugin, deletedTextDecorator],
+    plugins: [keymap(baseKeymap), suggestionModePlugin({
+      username: "example user",
+    }), deletedTextDecorator],
   });
 
   // Create the editor view

--- a/examples/simple/simple.ts
+++ b/examples/simple/simple.ts
@@ -16,6 +16,7 @@ import { Schema } from "prosemirror-model";
 
 // Import a theme for the suggestions or create your own
 import "prosemirror-suggestion-mode/styles/default.css";
+import "prosemirror-suggestion-mode/styles/default.css";
 
 const exampleSchema = new Schema({
   nodes: addListNodes(schema.spec.nodes, "paragraph block*", "block"),

--- a/examples/simple/simple.ts
+++ b/examples/simple/simple.ts
@@ -3,20 +3,19 @@ import { EditorView } from "prosemirror-view";
 import { baseKeymap } from "prosemirror-commands";
 import { keymap } from "prosemirror-keymap";
 import {
-  suggestionsPlugin,
+  suggestionModePlugin,
   acceptAllSuggestions,
   rejectAllSuggestions,
   setSuggestionMode,
-  suggestionsPluginKey,
-} from "prosemirror-suggest-mode";
-import { addSuggestionMarks } from "prosemirror-suggest-mode/schema";
+} from "prosemirror-suggestion-mode";
+import { addSuggestionMarks } from "prosemirror-suggestion-mode/schema";
 import { DOMParser } from "prosemirror-model";
 import { schema } from "prosemirror-schema-basic";
 import { addListNodes } from "prosemirror-schema-list";
 import { Schema } from "prosemirror-model";
 
 // Import a theme for the suggestions or create your own
-import "prosemirror-suggest-mode/styles/default.css";
+import "prosemirror-suggestion-mode/styles/default.css";
 
 const exampleSchema = new Schema({
   nodes: addListNodes(schema.spec.nodes, "paragraph block*", "block"),
@@ -41,21 +40,19 @@ window.addEventListener("load", () => {
   const state = EditorState.create({
     schema: exampleSchema,
     doc,
-    plugins: [keymap(baseKeymap), suggestionsPlugin],
+    plugins: [
+      keymap(baseKeymap), // basic keymap for the editor 
+      // suggestion mode plugin factory function with init values
+      suggestionModePlugin({ 
+        username: "example user", 
+        data: { // put any custom ata here that you want added as attrs to the hover tooltip
+            exampleattr: "these get added to the attrs of the the hover tooltip" 
+          } 
+      })],
   });
 
   // Create the editor view
   const view = new EditorView(document.querySelector("#editor"), { state });
-
-  // set the username of the editor
-  view.dispatch(
-    view.state.tr.setMeta(suggestionsPluginKey, {
-      username: "Your username",
-      data: {
-        exampleattr: "these get added to the attrs of the the hover tooltip",
-      },
-    })
-  );
 
   // Add event listeners for the controls
   document

--- a/examples/suggestEdit/index.html
+++ b/examples/suggestEdit/index.html
@@ -36,7 +36,7 @@
     </style>
 </head>
 <body>
-    <h1>Prosemirror-suggestions-mode suggestEdit Example</h1>
+    <h1>Prosemirror-suggestion-mode suggestEdit Example</h1>
 
     <p>Will apply these suggestions to the editor:</p>
 

--- a/examples/suggestEdit/index.html
+++ b/examples/suggestEdit/index.html
@@ -41,7 +41,7 @@
     <p>Will apply these suggestions to the editor:</p>
 
     <div class="suggestions-container">
-        <div id="suggestions"></div>
+        <pre id="suggestions"></pre>
     
 
     You can apply the suggestions with this tool 

--- a/examples/suggestEdit/suggestEditDemo.ts
+++ b/examples/suggestEdit/suggestEditDemo.ts
@@ -12,7 +12,7 @@ import {
   suggestEdit,
   TextSuggestion,
   addSuggestionMarks,
-} from "prosemirror-suggest-mode";
+} from "prosemirror-suggestion-mode";
 import { DOMParser } from "prosemirror-model";
 import { schema } from "prosemirror-schema-basic";
 
@@ -25,7 +25,7 @@ const exampleSchema = new Schema({
 });
 
 // Normally you can just direct import a theme
-import "prosemirror-suggest-mode/styles/default.css";
+import "prosemirror-suggestion-mode/styles/default.css";
 
 // Initialize the editor with the suggestions plugin
 window.addEventListener("load", () => {

--- a/examples/suggestEdit/suggestEditDemo.ts
+++ b/examples/suggestEdit/suggestEditDemo.ts
@@ -27,6 +27,32 @@ const exampleSchema = new Schema({
 // Normally you can just direct import a theme
 import "prosemirror-suggestion-mode/styles/default.css";
 
+// Create a custom component for displaying suggestion reason in the hover menu
+const createSuggestionReasonComponent = (mark: any, view: EditorView, pos: number): { dom: HTMLElement } => {
+  // Skip if not a suggestion mark
+  if (!mark.type.name.startsWith('suggestion_')) {
+    return { dom: document.createElement('div') };
+  }
+
+  const reasonDiv = document.createElement('div');
+  reasonDiv.className = 'suggestion-reason';
+  const reason = mark.attrs.data?.reason;
+  console.log('reason', reason, 'mark', mark);
+  if (reason) {
+    const reasonLabel = document.createElement('strong');
+    reasonLabel.textContent = 'Reason: ';
+    
+    const reasonText = document.createElement('span');
+    reasonText.textContent = reason;
+    reasonText.className = 'reason-content';
+    
+    reasonDiv.appendChild(reasonLabel);
+    reasonDiv.appendChild(reasonText);
+  }
+  
+  return { dom: reasonDiv };
+};
+
 // Initialize the editor with the suggestions plugin
 window.addEventListener("load", () => {
   // === REGULAR EDITOR SETUP ===
@@ -45,6 +71,12 @@ window.addEventListener("load", () => {
     doc,
     plugins: [keymap(baseKeymap), suggestionModePlugin({
       username: "example user",
+      // Add hover menu options to show suggestion reasons
+      hoverMenuOptions: {
+        components: {
+          createInfoComponent: createSuggestionReasonComponent
+        }
+      }
     })],
   });
 
@@ -122,34 +154,7 @@ window.addEventListener("load", () => {
 
   const suggestionsDiv = document.querySelector("#suggestions");
 
-  // Format the suggestions for display
-  let formattedText = "[\n";
-
-  exampleSuggestions.forEach((suggestion, index) => {
-    formattedText += "  {\n";
-    formattedText += `    textToReplace: "${suggestion.textToReplace}",\n`;
-    formattedText += `    textReplacement: "${suggestion.textReplacement}",\n`;
-
-    if (suggestion.reason) {
-      formattedText += `    reason: "${suggestion.reason}",\n`;
-    }
-
-    if (suggestion.textBefore) {
-      formattedText += `    textBefore: "${suggestion.textBefore}",\n`;
-    }
-
-    if (suggestion.textAfter) {
-      formattedText += `    textAfter: "${suggestion.textAfter}",\n`;
-    }
-
-    // Remove trailing comma for the last property
-    formattedText = formattedText.slice(0, -2) + "\n";
-    formattedText +=
-      "  }" + (index < exampleSuggestions.length - 1 ? ",\n" : "\n");
-  });
-
-  formattedText += "]";
 
   // Use a pre element to preserve formatting
-  suggestionsDiv.innerHTML = `<pre>${formattedText}</pre>`;
+  suggestionsDiv.innerHTML = `<pre>${JSON.stringify(exampleSuggestions, null, 2)}</pre>`;
 });

--- a/examples/suggestEdit/suggestEditDemo.ts
+++ b/examples/suggestEdit/suggestEditDemo.ts
@@ -5,7 +5,7 @@ import { keymap } from "prosemirror-keymap";
 import { addListNodes } from "prosemirror-schema-list";
 import { Schema } from "prosemirror-model";
 import {
-  suggestionsPlugin,
+  suggestionModePlugin,
   acceptAllSuggestions,
   rejectAllSuggestions,
   setSuggestionMode,
@@ -43,7 +43,9 @@ window.addEventListener("load", () => {
   const state = EditorState.create({
     schema: exampleSchema,
     doc,
-    plugins: [keymap(baseKeymap), suggestionsPlugin],
+    plugins: [keymap(baseKeymap), suggestionModePlugin({
+      username: "example user",
+    })],
   });
 
   // Create the editor view

--- a/examples/suggestEdit/suggestEditDemo.ts
+++ b/examples/suggestEdit/suggestEditDemo.ts
@@ -37,7 +37,6 @@ const createSuggestionReasonComponent = (mark: any, view: EditorView, pos: numbe
   const reasonDiv = document.createElement('div');
   reasonDiv.className = 'suggestion-reason';
   const reason = mark.attrs.data?.reason;
-  console.log('reason', reason, 'mark', mark);
   if (reason) {
     const reasonLabel = document.createElement('strong');
     reasonLabel.textContent = 'Reason: ';

--- a/managing.md
+++ b/managing.md
@@ -19,7 +19,7 @@ npm test
 ## Deploying to netlify
 
 ```bash
-npm run deploy:netlify
+npm run deploy:netlify:prod
 ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prosemirror-suggestion-mode",
-  "version": "1.0.01",
+  "version": "1.0.03",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prosemirror-suggestion-mode",
-      "version": "1.0.01",
+      "version": "1.0.03",
       "dependencies": {
         "prosemirror-history": "^1.4.1",
         "prosemirror-model": "^1.19.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prosemirror-suggestion-mode",
-  "version": "1.0.03",
+  "version": "1.0.11",
   "description": "ProseMirror extension for suggestion/track changes mode",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/releases
+++ b/releases
@@ -8,6 +8,7 @@
 - Fully renamed to prosemirror-suggestion-mode from prosemirror-suggestions to avoid confusion with another lib
 - Made the hover menu extendable
 - Added a new example called inkAndSwitch which shows how to use the suggestion mode in a more complex example
+- fixed suggestEdit demo to show reason in hover menu
 
 ## 1.0.01
 

--- a/releases
+++ b/releases
@@ -1,0 +1,14 @@
+# Release Notes
+
+
+## 1.0.11
+
+- Fixed issue where suggestion marks were not being removed when deleting text inside them
+- Fixed issue where doing a delete one character from a suggestion_add was not working
+- Fully renamed to prosemirror-suggestion-mode from prosemirror-suggestions to avoid confusion with another lib
+- Made the hover menu extendable
+- Added a new example called inkAndSwitch which shows how to use the suggestion mode in a more complex example
+
+## 1.0.01
+
+- Initial release

--- a/src/__mocks__/suggestions.ts
+++ b/src/__mocks__/suggestions.ts
@@ -1,3 +1,0 @@
-export const suggestionsPluginKey = {
-  getState: jest.fn(),
-};

--- a/src/hoverMenu.ts
+++ b/src/hoverMenu.ts
@@ -9,23 +9,120 @@ export type SuggestionHoverMenuRenderer = (
   pos: number
 ) => HTMLElement;
 
-// Default suggestion hover menu renderer
-export const defaultRenderSuggestionHoverMenu: SuggestionHoverMenuRenderer = (
+// Menu item interface
+export interface MenuComponent {
+  dom: HTMLElement;
+  update?: (mark: Mark, view: EditorView, pos: number) => void;
+}
+
+// Default components builders
+export const defaultComponents = {
+  // Creates the info section showing who made the change and when
+  createInfoComponent(mark: Mark): MenuComponent {
+    const infoText = document.createElement("div");
+    infoText.className = "suggestion-info";
+
+    const date = new Date(mark.attrs.createdAt).toLocaleDateString();
+    infoText.textContent =
+      mark.type.name === "suggestion_delete"
+        ? `Deleted by ${mark.attrs.username} on ${date}`
+        : `Added by ${mark.attrs.username} on ${date}`;
+
+    return { dom: infoText };
+  },
+
+  // Creates the buttons section with accept/reject
+  createButtonsComponent(
+    mark: Mark,
+    view: EditorView,
+    pos: number
+  ): MenuComponent {
+    const buttonsDiv = document.createElement("div");
+    buttonsDiv.className = "suggestion-buttons";
+
+    const acceptButton = document.createElement("button");
+    acceptButton.className = "suggestion-accept";
+    acceptButton.textContent = "Accept";
+    acceptButton.addEventListener("click", (e) => {
+      e.stopPropagation();
+      acceptSuggestion(view, mark, pos);
+    });
+
+    const rejectButton = document.createElement("button");
+    rejectButton.className = "suggestion-reject";
+    rejectButton.textContent = "Reject";
+    rejectButton.addEventListener("click", (e) => {
+      e.stopPropagation();
+      rejectSuggestion(view, mark, pos);
+    });
+
+    buttonsDiv.appendChild(acceptButton);
+    buttonsDiv.appendChild(rejectButton);
+
+    return { dom: buttonsDiv };
+  },
+};
+
+// Options for creating the hover menu
+export interface SuggestionHoverMenuOptions {
+  // Component factories - can be replaced or extended
+  components?: {
+    createInfoComponent?: (
+      mark: Mark,
+      view: EditorView,
+      pos: number
+    ) => MenuComponent;
+    createButtonsComponent?: (
+      mark: Mark,
+      view: EditorView,
+      pos: number
+    ) => MenuComponent;
+    // Add more component types as needed
+  };
+  // Additional components to include
+  additionalComponents?: ((
+    mark: Mark,
+    view: EditorView,
+    pos: number
+  ) => MenuComponent)[];
+  // CSS classes
+  menuClass?: string;
+}
+
+// Create a hover menu with the specified components
+export function createSuggestionHoverMenu(
   mark: Mark,
   view: EditorView,
-  pos: number
-): HTMLElement => {
+  pos: number,
+  options: SuggestionHoverMenuOptions = {}
+): HTMLElement {
+  // Create the menu container
   const menu = document.createElement("div");
-  menu.className = "suggestion-hover-menu";
+  menu.className = options.menuClass || "suggestion-hover-menu";
 
-  const date = new Date(mark.attrs.createdAt).toLocaleDateString();
-  const infoText = document.createElement("div");
-  infoText.className = "suggestion-info";
-  infoText.textContent =
-    mark.type.name === "suggestion_delete"
-      ? `Deleted by ${mark.attrs.username} on ${date}`
-      : `Added by ${mark.attrs.username} on ${date}`;
-  menu.appendChild(infoText);
+  // Use component factories or fall back to defaults
+  const components = options.components || {};
+
+  // Create and add the info component
+  const createInfo =
+    components.createInfoComponent || defaultComponents.createInfoComponent;
+  const infoComponent = createInfo(mark);
+  menu.appendChild(infoComponent.dom);
+
+  // Create and add the buttons component
+  const createButtons =
+    components.createButtonsComponent ||
+    defaultComponents.createButtonsComponent;
+  const buttonsComponent = createButtons(mark, view, pos);
+  menu.appendChild(buttonsComponent.dom);
+
+  // Add any additional components
+  if (options.additionalComponents) {
+    options.additionalComponents.forEach((createComponent) => {
+      const component = createComponent(mark, view, pos);
+      menu.appendChild(component.dom);
+    });
+  }
 
   // Add custom data as attributes to the menu element if present
   if (mark.attrs.data) {
@@ -44,29 +141,14 @@ export const defaultRenderSuggestionHoverMenu: SuggestionHoverMenuRenderer = (
     }
   }
 
-  // Add accept and reject buttons
-  const buttonsDiv = document.createElement("div");
-  buttonsDiv.className = "suggestion-buttons";
-
-  const acceptButton = document.createElement("button");
-  acceptButton.className = "suggestion-accept";
-  acceptButton.textContent = "Accept";
-  acceptButton.addEventListener("click", (e) => {
-    e.stopPropagation();
-    acceptSuggestion(view, mark, pos);
-  });
-
-  const rejectButton = document.createElement("button");
-  rejectButton.className = "suggestion-reject";
-  rejectButton.textContent = "Reject";
-  rejectButton.addEventListener("click", (e) => {
-    e.stopPropagation();
-    rejectSuggestion(view, mark, pos);
-  });
-
-  buttonsDiv.appendChild(acceptButton);
-  buttonsDiv.appendChild(rejectButton);
-  menu.appendChild(buttonsDiv);
-
   return menu;
+}
+
+// Default suggestion hover menu renderer
+export const defaultRenderSuggestionHoverMenu: SuggestionHoverMenuRenderer = (
+  mark: Mark,
+  view: EditorView,
+  pos: number
+): HTMLElement => {
+  return createSuggestionHoverMenu(mark, view, pos);
 };

--- a/src/hoverMenu.ts
+++ b/src/hoverMenu.ts
@@ -18,7 +18,7 @@ export interface MenuComponent {
 // Default components builders
 export const defaultComponents = {
   // Creates the info section showing who made the change and when
-  createInfoComponent(mark: Mark): MenuComponent {
+  createInfoComponent(mark: Mark, view: EditorView, pos: number): MenuComponent {
     const infoText = document.createElement("div");
     infoText.className = "suggestion-info";
 
@@ -79,12 +79,6 @@ export interface SuggestionHoverMenuOptions {
     ) => MenuComponent;
     // Add more component types as needed
   };
-  // Additional components to include
-  additionalComponents?: ((
-    mark: Mark,
-    view: EditorView,
-    pos: number
-  ) => MenuComponent)[];
   // CSS classes
   menuClass?: string;
 }
@@ -115,14 +109,6 @@ export function createSuggestionHoverMenu(
     defaultComponents.createButtonsComponent;
   const buttonsComponent = createButtons(mark, view, pos);
   menu.appendChild(buttonsComponent.dom);
-
-  // Add any additional components
-  if (options.additionalComponents) {
-    options.additionalComponents.forEach((createComponent) => {
-      const component = createComponent(mark, view, pos);
-      menu.appendChild(component.dom);
-    });
-  }
 
   // Add custom data as attributes to the menu element if present
   if (mark.attrs.data) {

--- a/src/hoverMenu.ts
+++ b/src/hoverMenu.ts
@@ -106,7 +106,7 @@ export function createSuggestionHoverMenu(
   // Create and add the info component
   const createInfo =
     components.createInfoComponent || defaultComponents.createInfoComponent;
-  const infoComponent = createInfo(mark);
+  const infoComponent = createInfo(mark, view, pos);
   menu.appendChild(infoComponent.dom);
 
   // Create and add the buttons component

--- a/src/hoverMenu.ts
+++ b/src/hoverMenu.ts
@@ -1,0 +1,72 @@
+import { Mark } from "prosemirror-model";
+import { EditorView } from "prosemirror-view";
+import { acceptSuggestion, rejectSuggestion } from "./tools/accept-reject";
+
+// Type for suggestion hover menu renderer function
+export type SuggestionHoverMenuRenderer = (
+  mark: Mark,
+  view: EditorView,
+  pos: number
+) => HTMLElement;
+
+// Default suggestion hover menu renderer
+export const defaultRenderSuggestionHoverMenu: SuggestionHoverMenuRenderer = (
+  mark: Mark,
+  view: EditorView,
+  pos: number
+): HTMLElement => {
+  const menu = document.createElement("div");
+  menu.className = "suggestion-hover-menu";
+
+  const date = new Date(mark.attrs.createdAt).toLocaleDateString();
+  const infoText = document.createElement("div");
+  infoText.className = "suggestion-info";
+  infoText.textContent =
+    mark.type.name === "suggestion_delete"
+      ? `Deleted by ${mark.attrs.username} on ${date}`
+      : `Added by ${mark.attrs.username} on ${date}`;
+  menu.appendChild(infoText);
+
+  // Add custom data as attributes to the menu element if present
+  if (mark.attrs.data) {
+    try {
+      const customData =
+        typeof mark.attrs.data === "string"
+          ? JSON.parse(mark.attrs.data)
+          : mark.attrs.data;
+
+      // Add data attributes to the menu element
+      Object.entries(customData).forEach(([key, value]) => {
+        menu.setAttribute(`data-${key}`, String(value));
+      });
+    } catch (error) {
+      console.error("Error processing suggestion data:", error);
+    }
+  }
+
+  // Add accept and reject buttons
+  const buttonsDiv = document.createElement("div");
+  buttonsDiv.className = "suggestion-buttons";
+
+  const acceptButton = document.createElement("button");
+  acceptButton.className = "suggestion-accept";
+  acceptButton.textContent = "Accept";
+  acceptButton.addEventListener("click", (e) => {
+    e.stopPropagation();
+    acceptSuggestion(view, mark, pos);
+  });
+
+  const rejectButton = document.createElement("button");
+  rejectButton.className = "suggestion-reject";
+  rejectButton.textContent = "Reject";
+  rejectButton.addEventListener("click", (e) => {
+    e.stopPropagation();
+    rejectSuggestion(view, mark, pos);
+  });
+
+  buttonsDiv.appendChild(acceptButton);
+  buttonsDiv.appendChild(rejectButton);
+  menu.appendChild(buttonsDiv);
+
+  return menu;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 // Export all public API components
-export { suggestionModePlugin as suggestionsPlugin } from "./suggestions";
-export { suggestionsPluginKey } from "./key";
-export type { SuggestionsPluginState } from "./key";
+export { suggestionModePlugin } from "./suggestions";
+export { suggestionModePluginKey } from "./key";
+export type { SuggestionModePluginState } from "./key";
 export { addSuggestionMarks } from "./schema";
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Export all public API components
-export { suggestionModePlugin } from "./suggestions";
+export { suggestionModePlugin, findMarkRange } from "./suggestions";
 export { suggestionModePluginKey } from "./key";
 export type { SuggestionModePluginState } from "./key";
 export { addSuggestionMarks } from "./schema";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Export all public API components
-export { suggestionsPlugin } from "./suggestions";
+export { suggestionModePlugin as suggestionsPlugin } from "./suggestions";
 export { suggestionsPluginKey } from "./key";
 export type { SuggestionsPluginState } from "./key";
 export { addSuggestionMarks } from "./schema";

--- a/src/key.ts
+++ b/src/key.ts
@@ -1,7 +1,7 @@
 import { PluginKey } from "prosemirror-state";
 
 // Define interfaces for plugin state
-export interface SuggestionsPluginState {
+export interface SuggestionModePluginState {
   inSuggestionMode: boolean;
   username: string;
   data?: Record<string, any>;
@@ -9,6 +9,6 @@ export interface SuggestionsPluginState {
 }
 
 // Plugin key for accessing the plugin state
-export const suggestionsPluginKey = new PluginKey<SuggestionsPluginState>(
+export const suggestionModePluginKey = new PluginKey<SuggestionModePluginState>(
   "suggestions"
 );

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -17,7 +17,7 @@
     z-index: 10;
     bottom: 100%; /* Position above the text */
     left: 0;
-    margin-bottom: 5px; /* Add space between hover-menu and text */
+    margin-bottom: 0px; /* Add space between hover-menu and text */
     box-shadow: 0 2px 5px rgba(0,0,0,0.2);
     min-width: 150px;
     white-space: nowrap;

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -7,7 +7,7 @@
     text-decoration: line-through;
     color: red;
 }
-.suggestion-tooltip {
+.suggestion-hover-menu {
     background-color: #f0f0f0;
     padding: 5px;
     border-radius: 4px;
@@ -17,20 +17,21 @@
     z-index: 10;
     bottom: 100%; /* Position above the text */
     left: 0;
-    margin-bottom: 5px; /* Add space between tooltip and text */
+    margin-bottom: 5px; /* Add space between hover-menu and text */
     box-shadow: 0 2px 5px rgba(0,0,0,0.2);
     min-width: 150px;
     white-space: nowrap;
     transition-delay: 0.1s;
     transition-property: display;
+    color: black;
 }
 
-/* Create a relative positioning context for the tooltip */
+/* Create a relative positioning context for the hover-menu */
 .suggestion-add, .suggestion-delete {
     position: relative;
 }
 
-/* Add a pseudo-element to bridge the gap between suggestion and tooltip */
+/* Add a pseudo-element to bridge the gap between suggestion and hover-menu */
 .suggestion-add::before, 
 .suggestion-delete::before {
     content: '';
@@ -39,13 +40,13 @@
     width: 100%;
     bottom: 100%;
     left: 0;
-    z-index: 9; /* Below the tooltip but still part of the hover path */
+    z-index: 9; /* Below the hover-menu but still part of the hover path */
 }
 
-/* Show tooltip when hovering over suggestion marks */
-.suggestion-delete:hover .suggestion-tooltip,
-.suggestion-add:hover .suggestion-tooltip,
-.suggestion-tooltip:hover {
+/* Show hover-menu when hovering over suggestion marks */
+.suggestion-delete:hover .suggestion-hover-menu,
+.suggestion-add:hover .suggestion-hover-menu,
+.suggestion-hover-menu:hover {
     display: block;
 }
 

--- a/src/styles/inkAndSwitch.css
+++ b/src/styles/inkAndSwitch.css
@@ -37,10 +37,12 @@ where the deletions are hidden but shown on hover
     margin-bottom: 5px; /* Add space between hover-menu and text */
     box-shadow: 0 2px 5px rgba(0,0,0,0.2);
     min-width: 150px;
-    white-space: nowrap;
+    white-space: normal; /* Allow wrapping */
     transition-delay: 0.1s;
     transition-property: display;
     color: black;
+    max-width: 300px;
+    overflow-wrap: break-word; /* Add this */
 }
 
 /* Create a relative positioning context for the hover-menu */
@@ -109,29 +111,27 @@ where the deletions are hidden but shown on hover
 .suggestion-deleted-content {
     background-color: #fff0f0;
     border: 1px solid #ffcccc;
-  }
+}
   
-  .deleted-text-content {
+.deleted-text-content {
     font-style: italic;
     color: #d32f2f;
     padding: 3px;
     background-color: rgba(241, 157, 157);
     border-radius: 2px;
-  }
-  
-  /* Make sure your hover effect works with the new class */
-  .suggestion-delete:hover .deleted-text-content {
-    display: block;
-    position: absolute;
-    top: 100%;
-    left: 0%;
-  }
+    word-break: break-word;
+    white-space: normal; /* Ensure text wrapping */
+    overflow-wrap: break-word; /* Modern property for breaking words */
+    max-width: 100%; /* Stay within parent container */
+    display: inline-block; /* Respect container width */
+}
 
-  .deleted-text-content::after {
-    content: "";
-    width: 0px;
-    height: 0px;
-    display: inline;
-  }
+/* Add a class for the deleted text container */
+.suggestion-deleted-text {
+    max-width: 100%;
+    overflow-wrap: break-word;
+    white-space: normal;
+}
+  
 
   

--- a/src/styles/inkAndSwitch.css
+++ b/src/styles/inkAndSwitch.css
@@ -24,7 +24,7 @@ where the deletions are hidden but shown on hover
     color: red;
 }
 
-.suggestion-tooltip {
+.suggestion-hover-menu {
     background-color: #f0f0f0;
     padding: 5px;
     border-radius: 4px;
@@ -34,20 +34,21 @@ where the deletions are hidden but shown on hover
     z-index: 10;
     bottom: 100%; /* Position above the text */
     left: 0;
-    margin-bottom: 5px; /* Add space between tooltip and text */
+    margin-bottom: 5px; /* Add space between hover-menu and text */
     box-shadow: 0 2px 5px rgba(0,0,0,0.2);
     min-width: 150px;
     white-space: nowrap;
     transition-delay: 0.1s;
     transition-property: display;
+    color: black;
 }
 
-/* Create a relative positioning context for the tooltip */
+/* Create a relative positioning context for the hover-menu */
 .suggestion-add, .suggestion-delete {
     position: relative;
 }
 
-/* Add a pseudo-element to bridge the gap between suggestion and tooltip */
+/* Add a pseudo-element to bridge the gap between suggestion and hover-menu */
 .suggestion-add::before, 
 .suggestion-delete::before {
     content: '';
@@ -59,10 +60,10 @@ where the deletions are hidden but shown on hover
     z-index: 9; /* Below the tooltfip but still part of the hover path */
 }
 
-/* Show tooltip when hovering over suggestion marks */
-.suggestion-delete:hover .suggestion-tooltip,
-.suggestion-add:hover .suggestion-tooltip,
-.suggestion-tooltip:hover {
+/* Show hover-menu when hovering over suggestion marks */
+.suggestion-delete:hover .suggestion-hover-menu,
+.suggestion-add:hover .suggestion-hover-menu,
+.suggestion-hover-menu:hover {
     display: block;
 }
 

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -125,7 +125,7 @@ export const suggestionModePlugin = (
                 newState.schema.marks.suggestion_delete.create({
                   createdAt: Date.now(),
                   username: pluginState.username,
-                  data: { ...pluginState.data, ...meta.data },
+                  data: { ...pluginState.data, ...meta?.data || {} },
                 })
               );
               changed = true;
@@ -163,7 +163,7 @@ export const suggestionModePlugin = (
                 newState.schema.marks.suggestion_add.create({
                   createdAt: Date.now(),
                   username: pluginState.username,
-                  data: { ...pluginState.data, ...meta.data },
+                  data: { ...pluginState.data, ...meta?.data || {} },
                 })
               );
               changed = true;

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -4,67 +4,273 @@ import { Mark, Node } from "prosemirror-model";
 import { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { SuggestionsPluginState, suggestionsPluginKey } from "./key";
 import { acceptSuggestion, rejectSuggestion } from "./tools/accept-reject";
+import {
+  SuggestionHoverMenuRenderer,
+  defaultRenderSuggestionHoverMenu,
+} from "./suggestionHoverMenu";
 
-// Default tooltip renderer
-const renderTooltip = (
-  mark: Mark,
-  view: EditorView,
-  pos: number
-): HTMLElement => {
-  const tooltip = document.createElement("div");
-  tooltip.className = "suggestion-tooltip";
+// Plugin options interface
+export interface SuggestionModePluginOptions {
+  username?: string; // username of the user who is making the suggestion
+  data?: Record<string, any>; // custom data to be added to the suggestion hover menu
+  hoverMenuRenderer?: SuggestionHoverMenuRenderer; // custom renderer for the suggestion hover menu
+}
 
-  const date = new Date(mark.attrs.createdAt).toLocaleDateString();
-  const infoText = document.createElement("div");
-  infoText.className = "suggestion-info";
-  infoText.textContent =
-    mark.type.name === "suggestion_delete"
-      ? `Deleted by ${mark.attrs.username} on ${date}`
-      : `Added by ${mark.attrs.username} on ${date}`;
-  tooltip.appendChild(infoText);
+// Create the suggestions plugin
+export const suggestionModePlugin = (
+  options: SuggestionModePluginOptions = {}
+) => {
+  // Use provided hover menu renderer or fall back to default
+  const renderHoverMenu =
+    options.hoverMenuRenderer || defaultRenderSuggestionHoverMenu;
 
-  // Add custom data as attributes to the tooltip element if present
-  if (mark.attrs.data) {
-    try {
-      const customData =
-        typeof mark.attrs.data === "string"
-          ? JSON.parse(mark.attrs.data)
-          : mark.attrs.data;
+  return new Plugin({
+    key: suggestionsPluginKey,
 
-      // Add data attributes to the tooltip element
-      Object.entries(customData).forEach(([key, value]) => {
-        tooltip.setAttribute(`data-${key}`, String(value));
+    appendTransaction(
+      transactions: readonly Transaction[],
+      oldState: EditorState,
+      newState: EditorState
+    ) {
+      // handle when a selection is deleted
+      const pluginState = this.getState(oldState);
+      if (!pluginState?.inSuggestionMode) return null;
+
+      let tr = newState.tr;
+      let changed = false;
+
+      transactions.forEach((transaction) => {
+        // Skip if this is an internal operation
+        const meta = transaction.getMeta(suggestionsPluginKey);
+        if (meta && meta.suggestionOperation) {
+          return;
+        }
+
+        transaction.steps.forEach((step) => {
+          if (step instanceof ReplaceStep) {
+            const from = step.from;
+            const to = step.to;
+            const oldText = oldState.doc.textBetween(from, to, " ");
+            const newText = step.slice.content.textBetween(
+              0,
+              step.slice.content.size,
+              " "
+            );
+            const newFrom = from + oldText.length;
+            const newTo = newFrom + newText.length;
+            const isDelete = oldText.length > 0 && newText.length === 0;
+            const isAdd = oldText.length === 0 && newText.length > 0;
+            const isReplace = oldText.length > 0 && newText.length > 0;
+            // if from is inside a suggestion mark don't do anything
+            const from$ = newState.doc.resolve(from + (isDelete ? +1 : 0));
+            const marksAtFrom = from$.marks();
+            const fromMark = marksAtFrom.find(
+              (m) =>
+                m.type.name === "suggestion_add" ||
+                m.type.name === "suggestion_delete"
+            );
+            if (fromMark) {
+              // We are already inside a suggestion mark, let normal editing happen
+              return;
+            }
+            // Mark our next transactions as  internal suggestion operation so it won't be intercepted again
+            tr.setMeta(suggestionsPluginKey, {
+              suggestionOperation: true,
+              handled: true, // Add this flag to indicate this input has been handled
+            });
+
+            if (oldText.length > 0) {
+              // DELETE - reinsert removed text with a suggestion_delete mark
+              let markFrom = from;
+              let markTo = from + oldText.length;
+
+              // Check for adjacent suggestion_delete mark (on old version of doc)
+              const deleteMarkRange = findMarkRange(
+                newState,
+                markFrom,
+                "suggestion_delete"
+              );
+
+              tr.insertText(oldText, from, from);
+              if (deleteMarkRange) {
+                // Remove existing mark and expand mark range to include it
+                tr.removeMark(
+                  deleteMarkRange.from,
+                  deleteMarkRange.to,
+                  newState.schema.marks.suggestion_delete
+                );
+                // Expand range to include existing mark
+                markFrom = Math.min(
+                  markFrom,
+                  deleteMarkRange.from + oldText.length
+                );
+                markTo = Math.max(markTo, deleteMarkRange.to + oldText.length);
+              }
+
+              tr.addMark(
+                markFrom,
+                markTo,
+                newState.schema.marks.suggestion_delete.create({
+                  createdAt: Date.now(),
+                  username: pluginState.username,
+                  data: pluginState.data,
+                })
+              );
+              changed = true;
+            }
+
+            if (newText.length > 0) {
+              // ADD - insert new text with a suggestion_add mark
+              let markFrom = newFrom;
+              let markTo = newTo;
+
+              // Check for adjacent suggestion_add mark
+              const addMarkRange = findMarkRange(
+                newState,
+                newFrom,
+                "suggestion_add"
+              );
+
+              if (addMarkRange) {
+                // Remove existing mark
+                tr.removeMark(
+                  addMarkRange.from,
+                  addMarkRange.to,
+                  newState.schema.marks.suggestion_add
+                );
+
+                // Expand range to include existing mark
+                markFrom = Math.min(markFrom, addMarkRange.from);
+                markTo = Math.max(markTo, addMarkRange.to);
+              }
+
+              // somewhere else the insert already happens don't re-insert
+              tr.addMark(
+                markFrom,
+                markTo,
+                newState.schema.marks.suggestion_add.create({
+                  createdAt: Date.now(),
+                  username: pluginState.username,
+                  data: pluginState.data,
+                })
+              );
+              changed = true;
+            }
+
+            // if it's only a deletion, move the cursor to the start of the deleted text
+            const newCursorPos = newText.length > 0 ? newTo : from;
+            const Selection = newState.selection.constructor as any;
+            tr.setSelection(Selection.create(tr.doc, newCursorPos));
+          }
+        });
       });
-    } catch (error) {
-      console.error("Error processing suggestion data:", error);
-    }
-  }
 
-  // Add accept and reject buttons
-  const buttonsDiv = document.createElement("div");
-  buttonsDiv.className = "suggestion-buttons";
+      // Return the transaction if there were changes; otherwise return null
+      return changed ? tr : null;
+    },
 
-  const acceptButton = document.createElement("button");
-  acceptButton.className = "suggestion-accept";
-  acceptButton.textContent = "Accept";
-  acceptButton.addEventListener("click", (e) => {
-    e.stopPropagation();
-    acceptSuggestion(view, mark, pos);
+    state: {
+      init(): SuggestionsPluginState {
+        return {
+          inSuggestionMode: true,
+          username: options.username || "Anonymous",
+          data: options.data || {},
+        };
+      },
+
+      apply(
+        tr: Transaction,
+        value: SuggestionsPluginState
+      ): SuggestionsPluginState {
+        // If there's metadata associated with this transaction, merge it into the current state
+        const meta = tr.getMeta(suggestionsPluginKey);
+        if (meta) {
+          return {
+            ...value,
+            ...meta,
+          };
+        }
+        // Otherwise, return the existing state as-is
+        return value;
+      },
+    },
+
+    props: {
+      decorations(state: EditorState) {
+        const pluginState = this.getState(state);
+        if (!pluginState) return DecorationSet.empty;
+
+        const decos: Decoration[] = [];
+
+        state.doc.descendants((node: Node, pos: number) => {
+          // Handle suggestion_add marks
+          const addMark = node.marks.find(
+            (m: Mark) => m.type.name === "suggestion_add"
+          );
+          if (addMark) {
+            // Add inline decoration for the actual text
+            decos.push(
+              Decoration.inline(pos, pos + node.nodeSize, {
+                class: "suggestion-add",
+              })
+            );
+
+            // Add the hover menu within the wrapper
+            decos.push(
+              Decoration.widget(
+                pos,
+                (view) => {
+                  return renderHoverMenu(addMark, view, pos);
+                },
+                {
+                  side: 1,
+                  key: `suggestion-add-hover-menu-${pos}`,
+                  class: "suggestion-hover-menu-wrapper",
+                }
+              )
+            );
+          }
+
+          // Handle suggestion_delete marks
+          const delMark = node.marks.find(
+            (m: Mark) => m.type.name === "suggestion_delete"
+          );
+          if (delMark) {
+            // Create a wrapper for both the suggestion and its hover menu
+            decos.push(
+              Decoration.inline(pos, pos + node.nodeSize, {
+                class: "suggestion-wrapper suggestion-delete-wrapper",
+              })
+            );
+
+            // Add class to the node with the deletion mark
+            decos.push(
+              Decoration.inline(pos, pos + node.nodeSize, {
+                class: "suggestion-delete",
+              })
+            );
+
+            // Add hover menu for deleted text
+            decos.push(
+              Decoration.widget(
+                pos,
+                (view) => {
+                  return renderHoverMenu(delMark, view, pos);
+                },
+                {
+                  side: 1,
+                  key: `suggestion-delete-hover-menu-${pos}`,
+                  class: "suggestion-hover-menu-wrapper",
+                }
+              )
+            );
+          }
+        });
+
+        return DecorationSet.create(state.doc, decos);
+      },
+    },
   });
-
-  const rejectButton = document.createElement("button");
-  rejectButton.className = "suggestion-reject";
-  rejectButton.textContent = "Reject";
-  rejectButton.addEventListener("click", (e) => {
-    e.stopPropagation();
-    rejectSuggestion(view, mark, pos);
-  });
-
-  buttonsDiv.appendChild(acceptButton);
-  buttonsDiv.appendChild(rejectButton);
-  tooltip.appendChild(buttonsDiv);
-
-  return tooltip;
 };
 
 // Function to find if a position is inside a mark and return its range
@@ -108,256 +314,3 @@ export const findMarkRange = (
 
   return { from, to, mark };
 };
-
-// Create the suggestions plugin
-export const suggestionsPlugin = new Plugin({
-  key: suggestionsPluginKey,
-
-  appendTransaction(
-    transactions: readonly Transaction[],
-    oldState: EditorState,
-    newState: EditorState
-  ) {
-    // handle when a selection is deleted
-    const pluginState = this.getState(oldState);
-    if (!pluginState?.inSuggestionMode) return null;
-
-    let tr = newState.tr;
-    let changed = false;
-
-    transactions.forEach((transaction) => {
-      // Skip if this is an internal operation
-      const meta = transaction.getMeta(suggestionsPluginKey);
-      if (meta && meta.suggestionOperation) {
-        return;
-      }
-
-      transaction.steps.forEach((step) => {
-        if (step instanceof ReplaceStep) {
-          const from = step.from;
-          const to = step.to;
-          const oldText = oldState.doc.textBetween(from, to, " ");
-          const newText = step.slice.content.textBetween(
-            0,
-            step.slice.content.size,
-            " "
-          );
-          const newFrom = from + oldText.length;
-          const newTo = newFrom + newText.length;
-          const isDelete = oldText.length > 0 && newText.length === 0;
-          const isAdd = oldText.length === 0 && newText.length > 0;
-          const isReplace = oldText.length > 0 && newText.length > 0;
-          // if from is inside a suggestion mark don't do anything
-          const from$ = newState.doc.resolve(from + (isDelete ? +1 : 0));
-          const marksAtFrom = from$.marks();
-          const fromMark = marksAtFrom.find(
-            (m) =>
-              m.type.name === "suggestion_add" ||
-              m.type.name === "suggestion_delete"
-          );
-          if (fromMark) {
-            console.log(
-              "already inside a suggestion mark, let normal editing happen",
-              from
-            );
-            // We are already inside a suggestion mark, let normal editing happen
-            return;
-          }
-          // Mark our next transactions as  internal suggestion operation so it won't be intercepted again
-          tr.setMeta(suggestionsPluginKey, {
-            suggestionOperation: true,
-            handled: true, // Add this flag to indicate this input has been handled
-          });
-
-          if (oldText.length > 0) {
-            // DELETE - reinsert removed text with a suggestion_delete mark
-            let markFrom = from;
-            let markTo = from + oldText.length;
-
-            // Check for adjacent suggestion_delete mark (on old version of doc)
-            const deleteMarkRange = findMarkRange(
-              newState,
-              markFrom,
-              "suggestion_delete"
-            );
-
-            tr.insertText(oldText, from, from);
-            if (deleteMarkRange) {
-              // Remove existing mark and expand mark range to include it
-              tr.removeMark(
-                deleteMarkRange.from,
-                deleteMarkRange.to,
-                newState.schema.marks.suggestion_delete
-              );
-              // Expand range to include existing mark
-              markFrom = Math.min(
-                markFrom,
-                deleteMarkRange.from + oldText.length
-              );
-              markTo = Math.max(markTo, deleteMarkRange.to + oldText.length);
-            }
-
-            tr.addMark(
-              markFrom,
-              markTo,
-              newState.schema.marks.suggestion_delete.create({
-                createdAt: Date.now(),
-                username: pluginState.username,
-                data: pluginState.data,
-              })
-            );
-            changed = true;
-          }
-
-          if (newText.length > 0) {
-            // ADD - insert new text with a suggestion_add mark
-            let markFrom = newFrom;
-            let markTo = newTo;
-
-            // Check for adjacent suggestion_add mark
-            const addMarkRange = findMarkRange(
-              newState,
-              newFrom,
-              "suggestion_add"
-            );
-
-            if (addMarkRange) {
-              // Remove existing mark
-              tr.removeMark(
-                addMarkRange.from,
-                addMarkRange.to,
-                newState.schema.marks.suggestion_add
-              );
-
-              // Expand range to include existing mark
-              markFrom = Math.min(markFrom, addMarkRange.from);
-              markTo = Math.max(markTo, addMarkRange.to);
-            }
-
-            // somewhere else the insert already happens don't re-insert
-            tr.addMark(
-              markFrom,
-              markTo,
-              newState.schema.marks.suggestion_add.create({
-                createdAt: Date.now(),
-                username: pluginState.username,
-                data: pluginState.data,
-              })
-            );
-            changed = true;
-          }
-
-          // if it's only a deletion, move the cursor to the start of the deleted text
-          const newCursorPos = newText.length > 0 ? newTo : from;
-          const Selection = newState.selection.constructor as any;
-          tr.setSelection(Selection.create(tr.doc, newCursorPos));
-        }
-      });
-    });
-
-    // Return the transaction if there were changes; otherwise return null
-    return changed ? tr : null;
-  },
-
-  state: {
-    init(): SuggestionsPluginState {
-      return {
-        inSuggestionMode: true,
-        username: "Anonymous",
-        data: {},
-      };
-    },
-
-    apply(
-      tr: Transaction,
-      value: SuggestionsPluginState
-    ): SuggestionsPluginState {
-      // If there's metadata associated with this transaction, merge it into the current state
-      const meta = tr.getMeta(suggestionsPluginKey);
-      if (meta) {
-        return {
-          ...value,
-          ...meta,
-        };
-      }
-      // Otherwise, return the existing state as-is
-      return value;
-    },
-  },
-
-  props: {
-    decorations(state: EditorState) {
-      const pluginState = this.getState(state);
-      if (!pluginState) return DecorationSet.empty;
-
-      const decos: Decoration[] = [];
-
-      state.doc.descendants((node: Node, pos: number) => {
-        // Handle suggestion_add marks
-        const addMark = node.marks.find(
-          (m: Mark) => m.type.name === "suggestion_add"
-        );
-        if (addMark) {
-          // Add inline decoration for the actual text
-          decos.push(
-            Decoration.inline(pos, pos + node.nodeSize, {
-              class: "suggestion-add",
-            })
-          );
-
-          // Add the tooltip within the wrapper
-          decos.push(
-            Decoration.widget(
-              pos,
-              (view) => {
-                return renderTooltip(addMark, view, pos);
-              },
-              {
-                side: 1,
-                key: `suggestion-add-tooltip-${pos}`,
-                class: "suggestion-tooltip-wrapper",
-              }
-            )
-          );
-        }
-
-        // Handle suggestion_delete marks
-        const delMark = node.marks.find(
-          (m: Mark) => m.type.name === "suggestion_delete"
-        );
-        if (delMark) {
-          // Create a wrapper for both the suggestion and its tooltip
-          decos.push(
-            Decoration.inline(pos, pos + node.nodeSize, {
-              class: "suggestion-wrapper suggestion-delete-wrapper",
-            })
-          );
-
-          // Add class to the node with the deletion mark
-          decos.push(
-            Decoration.inline(pos, pos + node.nodeSize, {
-              class: "suggestion-delete",
-            })
-          );
-
-          // Add tooltip for deleted text
-          decos.push(
-            Decoration.widget(
-              pos,
-              (view) => {
-                return renderTooltip(delMark, view, pos);
-              },
-              {
-                side: 1,
-                key: `suggestion-delete-tooltip-${pos}`,
-                class: "suggestion-tooltip-wrapper",
-              }
-            )
-          );
-        }
-      });
-
-      return DecorationSet.create(state.doc, decos);
-    },
-  },
-});

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -1,13 +1,12 @@
 import { Plugin, Transaction, EditorState } from "prosemirror-state";
 import { ReplaceStep } from "prosemirror-transform";
 import { Mark, Node } from "prosemirror-model";
-import { Decoration, DecorationSet, EditorView } from "prosemirror-view";
+import { Decoration, DecorationSet } from "prosemirror-view";
 import { SuggestionsPluginState, suggestionsPluginKey } from "./key";
-import { acceptSuggestion, rejectSuggestion } from "./tools/accept-reject";
 import {
   SuggestionHoverMenuRenderer,
   defaultRenderSuggestionHoverMenu,
-} from "./suggestionHoverMenu";
+} from "./hoverMenu";
 
 // Plugin options interface
 export interface SuggestionModePluginOptions {
@@ -25,7 +24,7 @@ export const suggestionModePlugin = (
     options.hoverMenuRenderer || defaultRenderSuggestionHoverMenu;
 
   return new Plugin({
-    key: suggestionsPluginKey,
+    key: suggestionModePluginKey,
 
     appendTransaction(
       transactions: readonly Transaction[],

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -80,7 +80,7 @@ export const suggestionModePlugin = (
             );
 
             if (isInsideSuggestionMark) {
-              console.log('isInsideSuggestionMark', isInsideSuggestionMark, from);
+              // console.log('isInsideSuggestionMark', isInsideSuggestionMark, from);
               // We are already inside a suggestion mark, let normal editing happen
               return;
             }

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -125,7 +125,7 @@ export const suggestionModePlugin = (
                 newState.schema.marks.suggestion_delete.create({
                   createdAt: Date.now(),
                   username: pluginState.username,
-                  data: pluginState.data,
+                  data: { ...pluginState.data, ...meta.data },
                 })
               );
               changed = true;
@@ -163,7 +163,7 @@ export const suggestionModePlugin = (
                 newState.schema.marks.suggestion_add.create({
                   createdAt: Date.now(),
                   username: pluginState.username,
-                  data: pluginState.data,
+                  data: { ...pluginState.data, ...meta.data },
                 })
               );
               changed = true;

--- a/src/tools/accept-reject.ts
+++ b/src/tools/accept-reject.ts
@@ -1,13 +1,13 @@
 import { EditorView } from "prosemirror-view";
 import { Mark } from "prosemirror-model";
-import { suggestionsPluginKey } from "../key";
+import { suggestionModePluginKey } from "../key";
 
 // Updated function to accept a suggestion without requiring type parameter
 export const acceptSuggestion = (view: EditorView, mark: Mark, pos: number) => {
   const tr = view.state.tr;
 
   // Mark this transaction as a suggestion operation so it won't be intercepted
-  tr.setMeta(suggestionsPluginKey, { suggestionOperation: true });
+  tr.setMeta(suggestionModePluginKey, { suggestionOperation: true });
 
   if (mark.type.name === "suggestion_add") {
     // For added text, we keep the text but remove the mark
@@ -58,7 +58,7 @@ export const rejectSuggestion = (view: EditorView, mark: Mark, pos: number) => {
   const tr = view.state.tr;
 
   // Mark this transaction as a suggestion operation so it won't be intercepted
-  tr.setMeta(suggestionsPluginKey, { suggestionOperation: true });
+  tr.setMeta(suggestionModePluginKey, { suggestionOperation: true });
 
   if (mark.type.name === "suggestion_add") {
     // For added text, we remove both the text and the mark

--- a/src/tools/setMode.ts
+++ b/src/tools/setMode.ts
@@ -1,14 +1,14 @@
 import { EditorView } from "prosemirror-view";
-import { suggestionsPluginKey } from "../key";
+import { suggestionModePluginKey } from "../key";
 
 export const setSuggestionMode = (
   view: EditorView,
   isSuggestionMode: boolean
 ) => {
-  const state = suggestionsPluginKey.getState(view.state);
+  const state = suggestionModePluginKey.getState(view.state);
   if (!state) return;
   view.dispatch(
-    view.state.tr.setMeta(suggestionsPluginKey, {
+    view.state.tr.setMeta(suggestionModePluginKey, {
       ...state,
       inSuggestionMode: isSuggestionMode,
     })

--- a/src/tools/setMode.ts
+++ b/src/tools/setMode.ts
@@ -1,5 +1,5 @@
 import { EditorView } from "prosemirror-view";
-import { suggestionsPlugin } from "../suggestions";
+import { suggestionModePlugin } from "../suggestions";
 import { suggestionsPluginKey } from "../key";
 
 export const setSuggestionMode = (
@@ -9,7 +9,7 @@ export const setSuggestionMode = (
   const state = suggestionsPluginKey.getState(view.state);
   if (!state) return;
   view.dispatch(
-    view.state.tr.setMeta(suggestionsPlugin, {
+    view.state.tr.setMeta(suggestionModePlugin, {
       ...state,
       inSuggestionMode: isSuggestionMode,
     })

--- a/src/tools/setMode.ts
+++ b/src/tools/setMode.ts
@@ -1,5 +1,4 @@
 import { EditorView } from "prosemirror-view";
-import { suggestionModePlugin } from "../suggestions";
 import { suggestionsPluginKey } from "../key";
 
 export const setSuggestionMode = (
@@ -9,7 +8,7 @@ export const setSuggestionMode = (
   const state = suggestionsPluginKey.getState(view.state);
   if (!state) return;
   view.dispatch(
-    view.state.tr.setMeta(suggestionModePlugin, {
+    view.state.tr.setMeta(suggestionsPluginKey, {
       ...state,
       inSuggestionMode: isSuggestionMode,
     })

--- a/src/tools/suggestEdit.ts
+++ b/src/tools/suggestEdit.ts
@@ -21,8 +21,6 @@ const replaceInProsemirror = (
 
   // Store reason in metadata if available
   if (suggestion.reason) {
-
-    console.log('setting reason', suggestion.reason);
     tr.setMeta(suggestionModePluginKey, {
       data: { reason: suggestion.reason },
     });

--- a/src/tools/suggestEdit.ts
+++ b/src/tools/suggestEdit.ts
@@ -21,6 +21,8 @@ const replaceInProsemirror = (
 
   // Store reason in metadata if available
   if (suggestion.reason) {
+
+    console.log('setting reason', suggestion.reason);
     tr.setMeta(suggestionModePluginKey, {
       data: { reason: suggestion.reason },
     });

--- a/src/tools/suggestEdit.ts
+++ b/src/tools/suggestEdit.ts
@@ -1,5 +1,5 @@
 import { EditorView } from "prosemirror-view";
-import { suggestionsPluginKey } from "../key";
+import { suggestionModePluginKey } from "../key";
 import { Node } from "prosemirror-model";
 
 export type TextSuggestion = {
@@ -21,7 +21,7 @@ const replaceInProsemirror = (
 
   // Store reason in metadata if available
   if (suggestion.reason) {
-    tr.setMeta(suggestionsPluginKey, {
+    tr.setMeta(suggestionModePluginKey, {
       data: { reason: suggestion.reason },
     });
   }
@@ -46,11 +46,11 @@ export const suggestEdit = (
   username: string
 ) => {
   // Store current state
-  const startingState = suggestionsPluginKey.getState(view.state);
+  const startingState = suggestionModePluginKey.getState(view.state);
   if (!startingState) return 0;
 
   view.dispatch(
-    view.state.tr.setMeta(suggestionsPluginKey, {
+    view.state.tr.setMeta(suggestionModePluginKey, {
       ...startingState,
       username,
       inSuggestionMode: true,
@@ -136,8 +136,8 @@ export const suggestEdit = (
 
   // Restore original username
   view.dispatch(
-    view.state.tr.setMeta(suggestionsPluginKey, {
-      ...suggestionsPluginKey.getState(view.state),
+    view.state.tr.setMeta(suggestionModePluginKey, {
+      ...suggestionModePluginKey.getState(view.state),
       username: startingState.username,
       data: startingState.data,
       inSuggestionMode: startingState.inSuggestionMode,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -46,24 +46,24 @@ declare module "prosemirror-model" {
 }
 
 // Module declarations for webpack alias
-declare module "prosemirror-suggest-mode" {
+declare module "prosemirror-suggestion-mode" {
   export * from "./index";
 }
 
-declare module "prosemirror-suggest-mode/suggestions" {
+declare module "prosemirror-suggestion-mode/suggestions" {
   export * from "./suggestions";
 }
 
-declare module "prosemirror-suggest-mode/schema" {
+declare module "prosemirror-suggestion-mode/schema" {
   export * from "./schema";
 }
 
-declare module "prosemirror-suggest-mode/styles/default.css" {
+declare module "prosemirror-suggestion-mode/styles/default.css" {
   const content: any;
   export default content;
 }
 
-declare module "prosemirror-suggest-mode/styles/inkAndSwitch.css" {
+declare module "prosemirror-suggestion-mode/styles/inkAndSwitch.css" {
   const content: any;
   export default content;
 }

--- a/test/helpers/test-helpers.ts
+++ b/test/helpers/test-helpers.ts
@@ -59,7 +59,7 @@ export function createEditorState(doc: string, plugins: Plugin[] = []) {
 
   return EditorState.create({
     doc: DOMParser.fromSchema(testSchema).parse(element),
-    plugins: [suggestionModePlugin, ...plugins],
+    plugins: [suggestionModePlugin({ username: "test" }), ...plugins],
   });
 }
 

--- a/test/helpers/test-helpers.ts
+++ b/test/helpers/test-helpers.ts
@@ -7,7 +7,7 @@ import {
 import { EditorView } from "prosemirror-view";
 import { Schema, DOMParser } from "prosemirror-model";
 import { suggestionModePlugin } from "../../src/suggestions";
-import { suggestionsPluginKey } from "../../src/key";
+import { suggestionModePluginKey } from "../../src/key";
 
 // Define a basic schema for testing
 export const testSchema = new Schema({

--- a/test/helpers/test-helpers.ts
+++ b/test/helpers/test-helpers.ts
@@ -1,46 +1,65 @@
-import { EditorState, Plugin, Selection, TextSelection } from "prosemirror-state";
+import {
+  EditorState,
+  Plugin,
+  Selection,
+  TextSelection,
+} from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { Schema, DOMParser } from "prosemirror-model";
-import { suggestionsPlugin } from "../../src/suggestions";
+import { suggestionModePlugin } from "../../src/suggestions";
 import { suggestionsPluginKey } from "../../src/key";
 
 // Define a basic schema for testing
 export const testSchema = new Schema({
   nodes: {
     doc: {
-      content: "paragraph+"
+      content: "paragraph+",
     },
     paragraph: {
       content: "text*",
-      toDOM() { return ["p", 0]; },
-      parseDOM: [{ tag: "p" }]
+      toDOM() {
+        return ["p", 0];
+      },
+      parseDOM: [{ tag: "p" }],
     },
     text: {
-      group: "inline"
-    }
+      group: "inline",
+    },
   },
   marks: {
     suggestion_add: {
-      attrs: { username: { default: "" }, createdAt: { default: 0 }, data: { default: null } },
-      toDOM() { return ["span", { class: "suggestion-add" }, 0]; },
-      parseDOM: [{ tag: "span.suggestion-add" }]
+      attrs: {
+        username: { default: "" },
+        createdAt: { default: 0 },
+        data: { default: null },
+      },
+      toDOM() {
+        return ["span", { class: "suggestion-add" }, 0];
+      },
+      parseDOM: [{ tag: "span.suggestion-add" }],
     },
     suggestion_delete: {
-      attrs: { username: { default: "" }, createdAt: { default: 0 }, data: { default: null } },
-      toDOM() { return ["span", { class: "suggestion-delete" }, 0]; },
-      parseDOM: [{ tag: "span.suggestion-delete" }]
-    }
-  }
+      attrs: {
+        username: { default: "" },
+        createdAt: { default: 0 },
+        data: { default: null },
+      },
+      toDOM() {
+        return ["span", { class: "suggestion-delete" }, 0];
+      },
+      parseDOM: [{ tag: "span.suggestion-delete" }],
+    },
+  },
 });
 
 // Helper to create an editor state with our plugin
 export function createEditorState(doc: string, plugins: Plugin[] = []) {
   const element = document.createElement("div");
   element.innerHTML = doc;
-  
+
   return EditorState.create({
     doc: DOMParser.fromSchema(testSchema).parse(element),
-    plugins: [suggestionsPlugin, ...plugins]
+    plugins: [suggestionModePlugin, ...plugins],
   });
 }
 
@@ -63,9 +82,9 @@ export function setCursor(view: EditorView, pos: number) {
 export function insertText(view: EditorView, text: string) {
   const tr = view.state.tr.insertText(text);
   view.dispatch(tr);
-  
+
   // Give time for the appendTransaction to run
-  return new Promise<EditorView>(resolve => {
+  return new Promise<EditorView>((resolve) => {
     setTimeout(() => resolve(view), 0);
   });
 }
@@ -74,30 +93,32 @@ export function insertText(view: EditorView, text: string) {
 export function deleteText(view: EditorView, from: number, to: number) {
   const tr = view.state.tr.delete(from, to);
   view.dispatch(tr);
-  
+
   // Give time for the appendTransaction to run
-  return new Promise<EditorView>(resolve => {
+  return new Promise<EditorView>((resolve) => {
     setTimeout(() => resolve(view), 0);
   });
 }
 
 // Setup DOM environment for tests
 export function setupDOMEnvironment() {
-  if (typeof document === 'undefined') {
+  if (typeof document === "undefined") {
     (global as any).document = {
       createElement: jest.fn().mockImplementation((tag) => {
         return {
-          innerHTML: '',
+          innerHTML: "",
           appendChild: jest.fn(),
           classList: {
-            add: jest.fn()
+            add: jest.fn(),
           },
           addEventListener: jest.fn(),
           setAttribute: jest.fn(),
-          style: {}
+          style: {},
         };
       }),
-      createTextNode: jest.fn().mockImplementation((text) => ({ textContent: text }))
+      createTextNode: jest
+        .fn()
+        .mockImplementation((text) => ({ textContent: text })),
     };
   }
 }

--- a/test/integration/suggestions.integration.test.ts
+++ b/test/integration/suggestions.integration.test.ts
@@ -6,7 +6,7 @@ import {
 } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { Schema, DOMParser, MarkSpec } from "prosemirror-model";
-import { suggestionsPlugin } from "../../src/suggestions";
+import { suggestionModePlugin } from "../../src/suggestions";
 import { suggestionsPluginKey } from "../../src/key";
 import { schema as basicSchema } from "prosemirror-schema-basic";
 import { keymap } from "prosemirror-keymap";
@@ -69,7 +69,7 @@ describe("suggestionsPlugin integration", () => {
     state = EditorState.create({
       doc,
       schema,
-      plugins: [keymap(baseKeymap), suggestionsPlugin],
+      plugins: [keymap(baseKeymap), suggestionModePlugin],
     });
 
     // Create the editor view

--- a/test/integration/suggestions.integration.test.ts
+++ b/test/integration/suggestions.integration.test.ts
@@ -6,7 +6,7 @@ import {
 import { EditorView } from "prosemirror-view";
 import { Schema, DOMParser, Mark } from "prosemirror-model";
 import { suggestionModePlugin } from "../../src/suggestions";
-import { suggestionsPluginKey } from "../../src/key";
+import { suggestionModePluginKey } from "../../src/key";
 import { schema as basicSchema } from "prosemirror-schema-basic";
 import { keymap } from "prosemirror-keymap";
 import { baseKeymap } from "prosemirror-commands";
@@ -49,7 +49,7 @@ describe("suggestionsPlugin integration", () => {
 
     // Configure the plugin with the desired state
     view.dispatch(
-      view.state.tr.setMeta(suggestionsPluginKey, {
+      view.state.tr.setMeta(suggestionModePluginKey, {
         inSuggestionMode: true,
         username: "testUser",
         data: { "example-attr": "test value" },
@@ -72,8 +72,8 @@ describe("suggestionsPlugin integration", () => {
   describe("suggestion mode", () => {
     test("should initialize with suggestion mode enabled", () => {
       createEditor();
-      const pluginState = suggestionsPluginKey.getState(view.state);
-      
+      const pluginState = suggestionModePluginKey.getState(view.state);
+
       expect(pluginState).toBeDefined();
       expect(pluginState!.inSuggestionMode).toBe(true);
       expect(pluginState!.username).toBe("testUser");
@@ -83,31 +83,31 @@ describe("suggestionsPlugin integration", () => {
       createEditor();
 
       // Get initial state
-      let pluginState = suggestionsPluginKey.getState(view.state);
+      let pluginState = suggestionModePluginKey.getState(view.state);
       expect(pluginState).toBeDefined();
       expect(pluginState!.inSuggestionMode).toBe(true);
 
       // Toggle suggestion mode off
       view.dispatch(
-        view.state.tr.setMeta(suggestionsPluginKey, {
+        view.state.tr.setMeta(suggestionModePluginKey, {
           inSuggestionMode: false,
         })
       );
 
       // Check that it's off
-      pluginState = suggestionsPluginKey.getState(view.state);
+      pluginState = suggestionModePluginKey.getState(view.state);
       expect(pluginState).toBeDefined();
       expect(pluginState!.inSuggestionMode).toBe(false);
 
       // Toggle it back on
       view.dispatch(
-        view.state.tr.setMeta(suggestionsPluginKey, {
+        view.state.tr.setMeta(suggestionModePluginKey, {
           inSuggestionMode: true,
         })
       );
 
       // Check that it's on again
-      pluginState = suggestionsPluginKey.getState(view.state);
+      pluginState = suggestionModePluginKey.getState(view.state);
       expect(pluginState).toBeDefined();
       expect(pluginState!.inSuggestionMode).toBe(true);
     });

--- a/test/integration/suggestions.integration.test.ts
+++ b/test/integration/suggestions.integration.test.ts
@@ -226,8 +226,8 @@ describe("suggestionsPlugin integration", () => {
       expect(decorations.length).toBeGreaterThan(0);
 
       // Check that there's a tooltip
-      const tooltips = container.querySelectorAll(".suggestion-tooltip");
-      expect(tooltips.length).toBeGreaterThan(0);
+      const hoverMenu = container.querySelectorAll(".suggestion-hover-menu");
+      expect(hoverMenu.length).toBeGreaterThan(0);
     });
   });
 
@@ -299,7 +299,7 @@ describe("suggestionsPlugin integration", () => {
       createEditor("<p>Hello world</p>");
 
       // Add text to create a suggestion mark
-      const position = 6;
+      const position = 7;
       view.dispatch(
         view.state.tr.setSelection(
           Selection.near(view.state.doc.resolve(position))
@@ -319,8 +319,6 @@ describe("suggestionsPlugin integration", () => {
           });
         }
       );
-
-      console.log('text after insertion', view.state.doc.textContent);
       // Move cursor one character to the left (inside the suggestion mark)
       const positionInsideMark = position + "new".length;
 
@@ -334,11 +332,8 @@ describe("suggestionsPlugin integration", () => {
       view.dispatch(
         view.state.tr.delete(positionInsideMark, positionInsideMark + 1)
       );
-      console.log('text after deletion', view.state.doc.textContent);
-
-      console.log('marks at position', view.state.doc.nodeAt(positionInsideMark)?.marks);
       // The content after deletion should have no space between "new" and "world"
-      expect(view.state.doc.textContent).toBe("Hellonewworld");
+      expect(view.state.doc.textContent).toBe("Hello newworld");
 
       // Check what suggestion marks we have after the operation
       const suggestionMarkNames: ("suggestion_add" | "suggestion_delete")[] = [];

--- a/test/unit/accept-reject.test.ts
+++ b/test/unit/accept-reject.test.ts
@@ -1,15 +1,17 @@
 import { EditorView } from "prosemirror-view";
 import { Mark } from "prosemirror-model";
 import { acceptSuggestion, rejectSuggestion, acceptAllSuggestions, rejectAllSuggestions } from "../../src/tools/accept-reject";
-import { suggestionsPluginKey } from "../../src/key";
+import { suggestionModePluginKey } from "../../src/key";
 
 // Mock dependencies
 jest.mock("prosemirror-view");
-jest.mock("../../src/key", () => ({
-  suggestionsPluginKey: {
-    getState: jest.fn(),
-  },
-}));
+jest.mock("../../src/key", () => {
+  return {
+    suggestionModePluginKey: {
+      getState: jest.fn(),
+    },
+  };
+});
 
 describe("accept-reject functions", () => {
   let mockView: jest.Mocked<EditorView>;
@@ -103,7 +105,7 @@ describe("accept-reject functions", () => {
 
       // Should set meta to mark this as a suggestion operation
       expect(mockTr.setMeta).toHaveBeenCalledWith(
-        suggestionsPluginKey, 
+        suggestionModePluginKey, 
         { suggestionOperation: true }
       );
 
@@ -120,7 +122,7 @@ describe("accept-reject functions", () => {
 
       // Should set meta to mark this as a suggestion operation
       expect(mockTr.setMeta).toHaveBeenCalledWith(
-        suggestionsPluginKey, 
+        suggestionModePluginKey, 
         { suggestionOperation: true }
       );
 
@@ -139,7 +141,7 @@ describe("accept-reject functions", () => {
 
       // Should set meta to mark this as a suggestion operation
       expect(mockTr.setMeta).toHaveBeenCalledWith(
-        suggestionsPluginKey, 
+        suggestionModePluginKey, 
         { suggestionOperation: true }
       );
 
@@ -156,7 +158,7 @@ describe("accept-reject functions", () => {
 
       // Should set meta to mark this as a suggestion operation
       expect(mockTr.setMeta).toHaveBeenCalledWith(
-        suggestionsPluginKey, 
+        suggestionModePluginKey, 
         { suggestionOperation: true }
       );
 

--- a/test/unit/findMarkRange.test.ts
+++ b/test/unit/findMarkRange.test.ts
@@ -1,5 +1,5 @@
 import { findMarkRange } from "../../src/suggestions";
-import { suggestionsPluginKey } from "../../src/key";
+import { suggestionModePluginKey } from "../../src/key";
 import {
   createEditorState,
   createEditorView,
@@ -66,11 +66,11 @@ describe("findMarkRange", () => {
     await insertText(view, " awesome");
 
     // Toggle suggestion mode off and on to create a new mark session
-    const tr1 = view.state.tr.setMeta(suggestionsPluginKey, {
+    const tr1 = view.state.tr.setMeta(suggestionModePluginKey, {
       inSuggestionMode: false,
     });
     view.dispatch(tr1);
-    const tr2 = view.state.tr.setMeta(suggestionsPluginKey, {
+    const tr2 = view.state.tr.setMeta(suggestionModePluginKey, {
       inSuggestionMode: true,
     });
     view.dispatch(tr2);

--- a/test/unit/setMode.test.ts
+++ b/test/unit/setMode.test.ts
@@ -1,6 +1,6 @@
 import { EditorView } from "prosemirror-view";
 import { setSuggestionMode } from "../../src/tools/setMode";
-import { suggestionsPluginKey } from "../../src/key";
+import { suggestionModePluginKey } from "../../src/key";
 import { suggestionModePlugin } from "../../src/suggestions";
 // Mock dependencies
 jest.mock("prosemirror-view");
@@ -47,7 +47,7 @@ describe("setSuggestionMode", () => {
     };
 
     // Mock getState to return our plugin state
-    (suggestionsPluginKey.getState as jest.Mock).mockReturnValue(
+    (suggestionModePluginKey.getState as jest.Mock).mockReturnValue(
       mockPluginState
     );
   });
@@ -80,7 +80,7 @@ describe("setSuggestionMode", () => {
 
   test("should do nothing if plugin state is null", () => {
     // Mock getState to return null
-    (suggestionsPluginKey.getState as jest.Mock).mockReturnValueOnce(null);
+    (suggestionModePluginKey.getState as jest.Mock).mockReturnValueOnce(null);
 
     setSuggestionMode(mockView, true);
 

--- a/test/unit/setMode.test.ts
+++ b/test/unit/setMode.test.ts
@@ -1,7 +1,7 @@
 import { EditorView } from "prosemirror-view";
 import { setSuggestionMode } from "../../src/tools/setMode";
 import { suggestionsPluginKey } from "../../src/key";
-import { suggestionsPlugin } from "../../src/suggestions";
+import { suggestionModePlugin } from "../../src/suggestions";
 
 // Mock dependencies
 jest.mock("prosemirror-view");
@@ -57,7 +57,7 @@ describe("setSuggestionMode", () => {
     setSuggestionMode(mockView, true);
 
     // Should set meta with updated state
-    expect(mockTr.setMeta).toHaveBeenCalledWith(suggestionsPlugin, {
+    expect(mockTr.setMeta).toHaveBeenCalledWith(suggestionModePlugin, {
       ...mockPluginState,
       inSuggestionMode: true,
     });
@@ -70,7 +70,7 @@ describe("setSuggestionMode", () => {
     setSuggestionMode(mockView, false);
 
     // Should set meta with updated state
-    expect(mockTr.setMeta).toHaveBeenCalledWith(suggestionsPlugin, {
+    expect(mockTr.setMeta).toHaveBeenCalledWith(suggestionModePlugin, {
       ...mockPluginState,
       inSuggestionMode: false,
     });
@@ -97,7 +97,7 @@ describe("setSuggestionMode", () => {
 
     // Should preserve custom properties
     expect(mockTr.setMeta).toHaveBeenCalledWith(
-      suggestionsPlugin,
+      suggestionModePlugin,
       expect.objectContaining({
         customProp: "customValue",
         inSuggestionMode: true,

--- a/test/unit/setMode.test.ts
+++ b/test/unit/setMode.test.ts
@@ -4,13 +4,15 @@ import { suggestionModePluginKey } from "../../src/key";
 import { suggestionModePlugin } from "../../src/suggestions";
 // Mock dependencies
 jest.mock("prosemirror-view");
-jest.mock("../../src/key", () => ({
-  suggestionsPluginKey: {
-    getState: jest.fn(),
-  },
-}));
+jest.mock("../../src/key", () => {
+  return {
+    suggestionModePluginKey: {
+      getState: jest.fn(),
+    },
+  };
+});
 jest.mock("../../src/suggestions", () => ({
-  suggestionsPlugin: {},
+  suggestionModePlugin: {},
 }));
 
 describe("setSuggestionMode", () => {
@@ -56,7 +58,7 @@ describe("setSuggestionMode", () => {
     setSuggestionMode(mockView, true);
 
     // Should set meta with updated state
-    expect(mockTr.setMeta).toHaveBeenCalledWith(suggestionModePlugin, {
+    expect(mockTr.setMeta).toHaveBeenCalledWith(suggestionModePluginKey, {
       ...mockPluginState,
       inSuggestionMode: true,
     });
@@ -69,7 +71,7 @@ describe("setSuggestionMode", () => {
     setSuggestionMode(mockView, false);
 
     // Should set meta with updated state
-    expect(mockTr.setMeta).toHaveBeenCalledWith(suggestionModePlugin, {
+    expect(mockTr.setMeta).toHaveBeenCalledWith(suggestionModePluginKey, {
       ...mockPluginState,
       inSuggestionMode: false,
     });
@@ -96,7 +98,7 @@ describe("setSuggestionMode", () => {
 
     // Should preserve custom properties
     expect(mockTr.setMeta).toHaveBeenCalledWith(
-      suggestionsPluginKey,
+      suggestionModePluginKey,
       expect.objectContaining({
         customProp: "customValue",
         inSuggestionMode: true,

--- a/test/unit/setMode.test.ts
+++ b/test/unit/setMode.test.ts
@@ -2,7 +2,6 @@ import { EditorView } from "prosemirror-view";
 import { setSuggestionMode } from "../../src/tools/setMode";
 import { suggestionsPluginKey } from "../../src/key";
 import { suggestionModePlugin } from "../../src/suggestions";
-
 // Mock dependencies
 jest.mock("prosemirror-view");
 jest.mock("../../src/key", () => ({
@@ -97,7 +96,7 @@ describe("setSuggestionMode", () => {
 
     // Should preserve custom properties
     expect(mockTr.setMeta).toHaveBeenCalledWith(
-      suggestionModePlugin,
+      suggestionsPluginKey,
       expect.objectContaining({
         customProp: "customValue",
         inSuggestionMode: true,

--- a/test/unit/suggestions.test.ts
+++ b/test/unit/suggestions.test.ts
@@ -2,7 +2,7 @@ import { EditorState, Plugin } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { Schema, Node, Mark } from "prosemirror-model";
 import { suggestionModePlugin, findMarkRange } from "../../src/suggestions";
-import { suggestionsPluginKey } from "../../src/key";
+import { suggestionModePluginKey } from "../../src/key";
 
 // Mock dependencies
 jest.mock("prosemirror-view");
@@ -105,7 +105,7 @@ describe("suggestionsPlugin", () => {
     };
 
     // Mock getState to return our plugin state
-    (suggestionsPluginKey.getState as jest.Mock).mockReturnValue(
+    (suggestionModePluginKey.getState as jest.Mock).mockReturnValue(
       mockPluginState
     );
   });
@@ -267,21 +267,22 @@ describe("suggestionsPlugin", () => {
         create: jest.fn().mockReturnValue("decoration-set"),
       };
 
-      // Create mock Decoration and DecorationSet classes
+      // Create mock Decoration and DecorationSet classes with proper typing
       const mockInlineDecoration = { type: "inline" };
       const mockWidgetDecoration = { type: "widget" };
 
+      // Use type assertions to help TypeScript understand the function signatures
       const Decoration = {
-        inline: jest.fn().mockReturnValue(mockInlineDecoration),
-        widget: jest.fn().mockReturnValue(mockWidgetDecoration),
+        inline: jest.fn().mockReturnValue(mockInlineDecoration) as jest.Mock<any, [number, number, any]>,
+        widget: jest.fn().mockReturnValue(mockWidgetDecoration) as jest.Mock<any, [number, () => HTMLElement, any]>
       };
 
       const DecorationSet = {
-        create: jest.fn().mockReturnValue("decoration-set"),
+        create: jest.fn().mockReturnValue("decoration-set") as jest.Mock<any, [any, any[]]>,
         empty: "empty-decoration-set",
       };
 
-      // Mock the global objects
+      // Assign to global
       global.Decoration = Decoration;
       global.DecorationSet = DecorationSet;
 
@@ -291,15 +292,20 @@ describe("suggestionsPlugin", () => {
         mockDoc.descendants((node, pos) => {
           if (node.marks.some((m) => m.type.name === "suggestion_add")) {
             decos.push(
+              // @ts-ignore - Ignoring typing issues with mocks in tests
               Decoration.inline(pos, pos + node.nodeSize, {
                 class: "suggestion-add",
               })
             );
             decos.push(
-              Decoration.widget(pos, expect.any(Function), expect.any(Object))
+              // @ts-ignore - Ignoring typing issues with mocks in tests
+              Decoration.widget(pos, () => document.createElement("span"), { 
+                side: 1 
+              })
             );
           }
         });
+        // @ts-ignore - Ignoring typing issues with mocks in tests
         return DecorationSet.create(mockDoc, decos);
       };
 
@@ -379,20 +385,23 @@ describe("suggestionsPlugin", () => {
         mockDoc.descendants((node, pos) => {
           if (node.marks.some((m) => m.type.name === "suggestion_delete")) {
             decos.push(
+              // @ts-ignore - Ignoring typing issues with mocks in tests
               global.Decoration.inline(pos, pos + node.nodeSize, {
                 class: "suggestion-wrapper suggestion-delete-wrapper",
               })
             );
             decos.push(
+              // @ts-ignore - Ignoring typing issues with mocks in tests
               global.Decoration.inline(pos, pos + node.nodeSize, {
                 class: "suggestion-delete",
               })
             );
             decos.push(
+              // @ts-ignore - Ignoring typing issues with mocks in tests
               global.Decoration.widget(
                 pos,
-                expect.any(Function),
-                expect.any(Object)
+                () => document.createElement("span"),
+                { side: 1 }
               )
             );
           }
@@ -488,7 +497,7 @@ describe("suggestionsPlugin", () => {
       };
 
       // Mock getState to return our plugin state
-      (suggestionsPluginKey.getState as jest.Mock).mockReturnValue(
+      (suggestionModePluginKey.getState as jest.Mock).mockReturnValue(
         mockPluginState
       );
     });
@@ -520,17 +529,17 @@ describe("suggestionsPlugin", () => {
       };
       
       // Simulate setting meta on the transaction
-      mockTransaction.setMeta(suggestionsPluginKey, expectedMeta);
+      mockTransaction.setMeta(suggestionModePluginKey, expectedMeta);
       
       // Verify the transaction's setMeta was called with the correct parameters
-      expect(mockTransaction.setMeta).toHaveBeenCalledWith(suggestionsPluginKey, expectedMeta);
+      expect(mockTransaction.setMeta).toHaveBeenCalledWith(suggestionModePluginKey, expectedMeta);
     });
   });
 
   describe("plugin initialization", () => {
     test("should have the correct props", () => {
       expect(pluginInstance).toBeDefined();
-      expect(suggestionsPluginKey).toBeDefined();
+      expect(suggestionModePluginKey).toBeDefined();
       expect(pluginInstance.props).toBeDefined();
       expect(pluginInstance.props.decorations).toBeDefined();
     });

--- a/test/unit/suggestions.test.ts
+++ b/test/unit/suggestions.test.ts
@@ -1,7 +1,7 @@
 import { EditorState, Plugin } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { Schema, Node, Mark } from "prosemirror-model";
-import { suggestionsPlugin, findMarkRange } from "../../src/suggestions";
+import { suggestionModePlugin, findMarkRange } from "../../src/suggestions";
 import { suggestionsPluginKey } from "../../src/key";
 
 // Mock dependencies
@@ -418,15 +418,15 @@ describe("suggestionsPlugin", () => {
 
   describe("plugin initialization", () => {
     test("should have the correct props", () => {
-      expect(suggestionsPlugin).toBeDefined();
+      expect(suggestionModePlugin).toBeDefined();
       expect(suggestionsPluginKey).toBeDefined();
-      expect(suggestionsPlugin.props).toBeDefined();
-      expect(suggestionsPlugin.props.decorations).toBeDefined();
+      expect(suggestionModePlugin.props).toBeDefined();
+      expect(suggestionModePlugin.props.decorations).toBeDefined();
     });
 
     test("should initialize with default state", () => {
       // Access the init function directly from the plugin spec
-      const initFn = suggestionsPlugin.spec.state.init;
+      const initFn = suggestionModePlugin.spec.state.init;
 
       // Create mock config and state
       const mockConfig = {} as any;
@@ -443,7 +443,7 @@ describe("suggestionsPlugin", () => {
 
     test("should handle state updates", () => {
       // Access the apply function directly from the plugin spec
-      const applyFn = suggestionsPlugin.spec.state!.apply;
+      const applyFn = suggestionModePlugin.spec.state!.apply;
 
       // Create a mock transaction with metadata
       const mockTr = {
@@ -563,7 +563,7 @@ describe("suggestionsPlugin", () => {
       };
 
       // Call the apply function directly
-      const resultOn = suggestionsPlugin.spec.state.apply(
+      const resultOn = suggestionModePlugin.spec.state.apply(
         mockTr as any,
         pluginState,
         {} as any,
@@ -581,7 +581,7 @@ describe("suggestionsPlugin", () => {
       };
 
       // Call the apply function again
-      const resultOff = suggestionsPlugin.spec.state.apply(
+      const resultOff = suggestionModePlugin.spec.state.apply(
         mockTrOff as any,
         resultOn,
         {} as any,

--- a/test/unit/suggestions.test.ts
+++ b/test/unit/suggestions.test.ts
@@ -513,7 +513,7 @@ describe("suggestionsPlugin", () => {
       
       expect(defaultState).toEqual({
         inSuggestionMode: true,
-        username: "Anonymous",
+        username: "testUser",
         data: {},
       });
     });
@@ -556,7 +556,7 @@ describe("suggestionsPlugin", () => {
 
       expect(defaultState).toEqual({
         inSuggestionMode: true,
-        username: "Anonymous",
+        username: "testUser",
         data: {},
       });
     });

--- a/test/unit/suggestions.test.ts
+++ b/test/unit/suggestions.test.ts
@@ -33,6 +33,8 @@ describe("suggestionsPlugin", () => {
   let mockState: EditorState;
   let mockView: EditorView;
   let mockPluginState: any;
+  // Create a plugin instance for testing at the top level so it's available to all tests
+  const pluginInstance = suggestionModePlugin({ username: "testUser" });
 
   beforeEach(() => {
     // Reset mocks
@@ -416,17 +418,126 @@ describe("suggestionsPlugin", () => {
     });
   });
 
+  describe("suggestionModePlugin", () => {
+    beforeEach(() => {
+      // Reset mocks
+      jest.clearAllMocks();
+
+      // Setup mock schema
+      mockSchema = {
+        marks: {
+          suggestion_add: {
+            create: jest.fn().mockImplementation((attrs) => ({
+              type: { name: "suggestion_add" },
+              attrs: attrs,
+            })),
+          },
+          suggestion_delete: {
+            create: jest.fn().mockImplementation((attrs) => ({
+              type: { name: "suggestion_delete" },
+              attrs: attrs,
+            })),
+          },
+        },
+        nodes: {
+          doc: { createAndFill: jest.fn() },
+          paragraph: { createAndFill: jest.fn() },
+          text: jest.fn((text) => ({ text })),
+        },
+      } as unknown as Schema;
+
+      // Setup mock document
+      mockDoc = {
+        nodesBetween: jest.fn(),
+        textContent: "This is a test document",
+        descendants: jest.fn(),
+        content: { size: 100 },
+      } as unknown as Node;
+
+      // Setup mock state
+      mockState = {
+        schema: mockSchema,
+        doc: mockDoc,
+        tr: {
+          setMeta: jest.fn().mockReturnThis(),
+          addMark: jest.fn().mockReturnThis(),
+          removeMark: jest.fn().mockReturnThis(),
+          setSelection: jest.fn().mockReturnThis(),
+          getMeta: jest.fn().mockImplementation(() => null),
+          insertText: jest.fn().mockReturnThis(),
+          delete: jest.fn().mockReturnThis(),
+        },
+        selection: {
+          from: 0,
+          to: 10,
+          empty: false,
+        },
+      } as unknown as EditorState;
+
+      // Setup mock view
+      mockView = {
+        state: mockState,
+        dispatch: jest.fn(),
+      } as unknown as EditorView;
+
+      // Setup mock plugin state
+      mockPluginState = {
+        username: "testUser",
+        inSuggestionMode: false,
+        data: {},
+      };
+
+      // Mock getState to return our plugin state
+      (suggestionsPluginKey.getState as jest.Mock).mockReturnValue(
+        mockPluginState
+      );
+    });
+
+    test("should have the correct props", () => {
+      expect(pluginInstance.props).toBeDefined();
+      expect(pluginInstance.props.decorations).toBeDefined();
+    });
+    
+    test("state initialization", () => {
+      const initFn = pluginInstance.spec.state!.init;
+      const defaultState = initFn({} as any, {} as any);
+      
+      expect(defaultState).toEqual({
+        inSuggestionMode: true,
+        username: "Anonymous",
+        data: {},
+      });
+    });
+    
+    test("should handle meta updates", () => {
+      // Use the mockState's transaction that was set up in beforeEach
+      const mockTransaction = mockState.tr;
+      
+      // Create an expected meta update object
+      const expectedMeta = {
+        inSuggestionMode: true,
+        username: "testUser"
+      };
+      
+      // Simulate setting meta on the transaction
+      mockTransaction.setMeta(suggestionsPluginKey, expectedMeta);
+      
+      // Verify the transaction's setMeta was called with the correct parameters
+      expect(mockTransaction.setMeta).toHaveBeenCalledWith(suggestionsPluginKey, expectedMeta);
+    });
+  });
+
   describe("plugin initialization", () => {
     test("should have the correct props", () => {
-      expect(suggestionModePlugin).toBeDefined();
+      expect(pluginInstance).toBeDefined();
       expect(suggestionsPluginKey).toBeDefined();
-      expect(suggestionModePlugin.props).toBeDefined();
-      expect(suggestionModePlugin.props.decorations).toBeDefined();
+      expect(pluginInstance.props).toBeDefined();
+      expect(pluginInstance.props.decorations).toBeDefined();
     });
 
     test("should initialize with default state", () => {
       // Access the init function directly from the plugin spec
-      const initFn = suggestionModePlugin.spec.state.init;
+      const initFn = pluginInstance.spec.state!.init;
 
       // Create mock config and state
       const mockConfig = {} as any;
@@ -443,7 +554,7 @@ describe("suggestionsPlugin", () => {
 
     test("should handle state updates", () => {
       // Access the apply function directly from the plugin spec
-      const applyFn = suggestionModePlugin.spec.state!.apply;
+      const applyFn = pluginInstance.spec.state!.apply;
 
       // Create a mock transaction with metadata
       const mockTr = {
@@ -561,9 +672,9 @@ describe("suggestionsPlugin", () => {
           inSuggestionMode: true,
         }),
       };
-
-      // Call the apply function directly
-      const resultOn = suggestionModePlugin.spec.state.apply(
+      expect(pluginInstance.spec.state).toBeDefined();
+      // Call the apply function directly from the plugin instance
+      const resultOn = pluginInstance.spec.state!.apply(
         mockTr as any,
         pluginState,
         {} as any,
@@ -579,9 +690,9 @@ describe("suggestionsPlugin", () => {
           inSuggestionMode: false,
         }),
       };
-
+      expect(pluginInstance.spec.state).toBeDefined();
       // Call the apply function again
-      const resultOff = suggestionModePlugin.spec.state.apply(
+      const resultOff = pluginInstance.spec.state!.apply(
         mockTrOff as any,
         resultOn,
         {} as any,

--- a/test/unit/suggestions.test.ts
+++ b/test/unit/suggestions.test.ts
@@ -21,7 +21,7 @@ jest.mock("prosemirror-model");
 // Mock the key module but keep the actual key
 jest.mock("../../src/key", () => {
   return {
-    suggestionsPluginKey: {
+    suggestionModePluginKey: {
       getState: jest.fn(),
     },
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
     "types": ["jest", "node"],
     "baseUrl": ".",
     "paths": {
-      "prosemirror-suggest-mode/*": ["src/*"],
-      "prosemirror-suggest-mode": ["src"]
+      "prosemirror-suggestion-mode/*": ["src/*"],
+      "prosemirror-suggestion-mode": ["src"]
     }
   },
   "include": ["src/**/*", "examples/**/*"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
         extensions: ['.ts', '.js'],
         alias: {
             // Create aliases so examples can find the source files but also work for npm users
-            'prosemirror-suggest-mode': path.resolve(__dirname, 'src')
+            'prosemirror-suggestion-mode': path.resolve(__dirname, 'src')
         }
     },
     plugins: [


### PR DESCRIPTION
- Fixed issue where suggestion marks were not being removed when deleting text inside them
- Fixed issue where doing a delete one character from a suggestion_add was not working
- Fully renamed to prosemirror-suggestion-mode from prosemirror-suggestions to avoid confusion with another lib
- Made the hover menu extendable
- Added a new example called inkAndSwitch which shows how to use the suggestion mode in a more complex example
- fixed suggestEdit demo to show reason in hover menu
